### PR TITLE
Fix pipeline event timestamps

### DIFF
--- a/docker-run-log-pipeline-event.sh
+++ b/docker-run-log-pipeline-event.sh
@@ -20,10 +20,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Check that the correct number of arguments were provided.
-if [[ $# -ne 6 ]]; then
+if [[ $# -ne 5 ]]; then
     echo "Usage: ./docker-run-log-pipeline-event.sh
     [--profile-cpu <cpu-profile-output-path>] <user> <google-cloud-credentials-file-path>\
-           <pipeline-configuration-file-path> <run-id> <timestamp> <event-key>"
+           <pipeline-configuration-file-path> <run-id> <event-key>"
     echo "Updates pipeline event/status to a firebase table to aid in monitoring"
     exit
 fi
@@ -32,8 +32,7 @@ USER=$1
 INPUT_GOOGLE_CLOUD_CREDENTIALS=$2
 INPUT_PIPELINE_CONFIGURATION=$3
 RUN_ID=$4
-TIMESTAMP=$5
-EVENT_KEY=$6
+EVENT_KEY=$5
 
 # Build an image for this pipeline stage.
 docker build --build-arg INSTALL_CPU_PROFILER="$PROFILE_CPU" -t "$IMAGE_NAME" .

--- a/docker-run-log-pipeline-event.sh
+++ b/docker-run-log-pipeline-event.sh
@@ -44,7 +44,7 @@ if [[ "$PROFILE_CPU" = true ]]; then
 fi
 CMD="pipenv run $PROFILE_CPU_CMD python -u log_pipeline_event.py \
     \"$USER\" /credentials/google-cloud-credentials.json \
-    /data/pipeline-configuration.json \"$RUN_ID\" \"$TIMESTAMP\" \"$EVENT_KEY\"
+    /data/pipeline-configuration.json \"$RUN_ID\" \"$EVENT_KEY\"
 "
 container="$(docker container create ${SYS_PTRACE_CAPABILITY} -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
 echo "Created container $container"

--- a/log_pipeline_event.py
+++ b/log_pipeline_event.py
@@ -2,6 +2,7 @@ import argparse
 import json
 
 from core_data_modules.logging import Logger
+from core_data_modules.util import TimeUtils
 from storage.google_cloud import google_cloud_utils
 from pipeline_logs.firestore_pipeline_logger import FirestorePipelineLogger
 
@@ -10,7 +11,8 @@ from src.lib.configuration_objects import PipelineEvents
 
 log = Logger(__name__)
 
-def log_pipeline_event(user, google_cloud_credentials_file_path, pipeline_configuration_file_path, timestamp, run_id, event_key):
+
+def log_pipeline_event(user, google_cloud_credentials_file_path, pipeline_configuration_file_path, run_id, event_key):
     # Read the settings from the configuration file
     log.info("Loading Pipeline Configuration File...")
     with open(pipeline_configuration_file_path) as f:
@@ -22,14 +24,16 @@ def log_pipeline_event(user, google_cloud_credentials_file_path, pipeline_config
         pipeline_configuration.operations_dashboard.firebase_credentials_file_url
     ))
 
-    log.info(f"Updating PipelineStart event log for run_id: {run_id}")
-    firestore_pipeline_logger= FirestorePipelineLogger(pipeline_configuration.pipeline_name, run_id,
-                                                   firestore_pipeline_logs_table_credentials)
+    log.info(f"Writing {event_key} event log for run_id '{run_id}'")
+    firestore_pipeline_logger = FirestorePipelineLogger(pipeline_configuration.pipeline_name, run_id,
+                                                        firestore_pipeline_logs_table_credentials)
 
-    firestore_pipeline_logger.log_event(timestamp, event_key)
+    firestore_pipeline_logger.log_event(TimeUtils.utc_now_as_iso_string(), event_key)
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Updates current pipeline event/stage to a firebase table to aid in monitoring")
+    parser = argparse.ArgumentParser(
+        description="Updates current pipeline event/stage to a firebase table to aid in monitoring")
 
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
@@ -37,19 +41,18 @@ if __name__ == "__main__":
                              "credentials bucket")
     parser.add_argument("pipeline_configuration_file_path", metavar="pipeline-configuration-file",
                         help="Path to the pipeline configuration json file"),
-    parser.add_argument("timestamp", metavar="timestamp",
-                        help="current pipeline run start datetime")
     parser.add_argument("run_id", metavar="run-id",
                         help="Identifier of this pipeline run")
     parser.add_argument("event_key", metavar="event-key",
                         help="Key for this pipeline event/stage",
-                              choices= [PipelineEvents.PIPELINE_RUN_START, PipelineEvents.CODA_ADD, PipelineEvents.FETCHING_RAW_DATA,
-                                        PipelineEvents.GENERATING_OUTPUTS, PipelineEvents.CODA_GET,
-                                        PipelineEvents.GENERATING_AUTOMATED_ANALYSIS_FILES, PipelineEvents.BACKING_UP_DATA,
-                                        PipelineEvents.UPLOADING_ANALYSIS_FILES, PipelineEvents.UPLOADING_LOG_FILES,
-                                        PipelineEvents.PIPELINE_RUN_END]),
+                        choices=[PipelineEvents.PIPELINE_RUN_START, PipelineEvents.CODA_ADD,
+                                 PipelineEvents.FETCHING_RAW_DATA,
+                                 PipelineEvents.GENERATING_OUTPUTS, PipelineEvents.CODA_GET,
+                                 PipelineEvents.GENERATING_AUTOMATED_ANALYSIS_FILES, PipelineEvents.BACKING_UP_DATA,
+                                 PipelineEvents.UPLOADING_ANALYSIS_FILES, PipelineEvents.UPLOADING_LOG_FILES,
+                                 PipelineEvents.PIPELINE_RUN_END]),
 
     args = parser.parse_args()
 
     log_pipeline_event(args.user, args.google_cloud_credentials_file_path, args.pipeline_configuration_file_path,
-                       args.timestamp, args.run_id, args.event_key)
+                       args.run_id, args.event_key)

--- a/run_scripts/log_pipeline_event.sh
+++ b/run_scripts/log_pipeline_event.sh
@@ -17,9 +17,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ $# -ne 6 ]]; then
-    echo "Usage: ./log_pipeline_events.sh [--profile-cpu <cpu-profile-output-path>] <user> <google-cloud-credentials-file-path>\
-           <pipeline-configuration-file-path> <run-id> <timestamp> <event-key>"
+if [[ $# -ne 5 ]]; then
+    echo "Usage: ./log_pipeline_event.sh [--profile-cpu <cpu-profile-output-path>] <user> <google-cloud-credentials-file-path>\
+           <pipeline-configuration-file-path> <run-id> <event-key>"
     echo "Updates pipeline event/status to a firebase table to aid in monitoring"
     exit
 fi
@@ -28,9 +28,8 @@ USER=$1
 GOOGLE_CLOUD_CREDENTIALS_FILE_PATH=$2
 PIPELINE_CONFIGURATION_FILE_PATH=$3
 RUN_ID=$4
-TIMESTAMP=$5
-EVENT_KEY=$6
+EVENT_KEY=$5
 
 cd ..
 ./docker-run-log-pipeline-event.sh ${CPU_PROFILE_ARG} \
-    "$USER" "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$PIPELINE_CONFIGURATION_FILE_PATH" "$RUN_ID" "$TIMESTAMP" "$EVENT_KEY"
+    "$USER" "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$PIPELINE_CONFIGURATION_FILE_PATH" "$RUN_ID" "$EVENT_KEY"

--- a/run_scripts/run_bungoma_pipeline.sh
+++ b/run_scripts/run_bungoma_pipeline.sh
@@ -28,8 +28,7 @@ RUN_ID="$TIMESTAMP-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunStart"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunStart"
 
 ./1_bungoma_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
@@ -53,5 +52,4 @@ fi
 ./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" \
                         "$DATA_BACKUPS_DIR"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunEnd"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunEnd"

--- a/run_scripts/run_kiambu_pipeline.sh
+++ b/run_scripts/run_kiambu_pipeline.sh
@@ -28,8 +28,7 @@ RUN_ID="$TIMESTAMP-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunStart"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunStart"
 
 ./1_kiambu_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
@@ -53,5 +52,4 @@ fi
 ./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" \
                         "$DATA_BACKUPS_DIR"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunEnd"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunEnd"

--- a/run_scripts/run_kilifi_pipeline.sh
+++ b/run_scripts/run_kilifi_pipeline.sh
@@ -28,8 +28,7 @@ RUN_ID="$TIMESTAMP-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunStart"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunStart"
 
 ./1_kilifi_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
@@ -53,5 +52,4 @@ fi
 ./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" \
                         "$DATA_BACKUPS_DIR"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunEnd"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunEnd"


### PR DESCRIPTION
Updates the log_event script to write the current time rather than the time at which the pipeline started. When the pipeline was writing the pipeline start time, all previous logs from the same run were being overwritten, which is why pipeline start times weren't updating on the ops dashboard.