### PR TITLE
Add all locations pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.6-slim
 # Install Python tools (git + pipenv)
 RUN apt-get update && apt-get install -y git
 RUN pip install pipenv
-RUN apt-get update && apt-get install -y libgeos-dev libgdal-dev build-essential
 
 # Install memory_profiler if this script is run with PROFILE_MEMORY flag
 ARG INSTALL_MEMORY_PROFILER="false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.6-slim
 # Install Python tools (git + pipenv)
 RUN apt-get update && apt-get install -y git
 RUN pip install pipenv
+RUN apt-get update && apt-get install -y libgeos-dev libgdal-dev build-essential
 
 # Install memory_profiler if this script is run with PROFILE_MEMORY flag
 ARG INSTALL_MEMORY_PROFILER="false"

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -101,19 +101,6 @@ if __name__ == "__main__":
             individuals[i] = dict(individuals[i].items())
     log.info(f"Loaded {len(individuals)} individuals")
 
-    with open(f"{automated_analysis_output_dir}/{pipeline_configuration.pipeline_name}.txt", "w") as f:
-        for td in individuals:
-            if td[CONSENT_WITHDRAWN_KEY] == Codes.TRUE:
-                continue
-
-            plan = PipelineConfiguration.RQA_CODING_PLANS[1]
-            if plan.raw_field in td:
-                f.write(f"{td[plan.raw_field]}\n")
-
-            # for cc in plan.coding_configurations:
-            #     if cc.code_scheme.get_code_with_code_id(td[cc.coded_field][0]["CodeID"]).control_code == "NC":
-            #         f.write(f"{td[plan.raw_field]}\n")
-
     # Compute the number of messages, individuals, and relevant messages per episode and overall.
     log.info("Computing the per-episode and per-season engagement counts...")
     engagement_counts = OrderedDict()  # of episode name to counts

--- a/code_schemes/all_locations_baseline_community_awareness.json
+++ b/code_schemes/all_locations_baseline_community_awareness.json
@@ -1,0 +1,224 @@
+{
+  "SchemeID": "Scheme-4730127b",
+  "Name": "All Locations Baseline Community Awareness",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_baseline_community_awareness.json
+++ b/code_schemes/all_locations_baseline_community_awareness.json
@@ -4,6 +4,46 @@
   "Version": "0.0.0.1",
   "Codes": [
     {
+      "CodeID": "code-e8816593",
+      "CodeType": "Normal",
+      "DisplayText": "not informed at all",
+      "NumericValue": 1,
+      "StringValue": "not_informed_at_all",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-217a16fc",
+      "CodeType": "Normal",
+      "DisplayText": "a little bit informed",
+      "NumericValue": 2,
+      "StringValue": "a_little_bit_informed",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6bddc38d",
+      "CodeType": "Normal",
+      "DisplayText": "well informed",
+      "NumericValue": 3,
+      "StringValue": "well_informed",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-2e2c4af3",
+      "CodeType": "Normal",
+      "DisplayText": "very well informed",
+      "NumericValue": 4,
+      "StringValue": "very_well_informed",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a72a3023",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 5,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-NA-f93d3eb7",
       "CodeType": "Control",
       "ControlCode": "NA",

--- a/code_schemes/all_locations_baseline_government_role.json
+++ b/code_schemes/all_locations_baseline_government_role.json
@@ -1,0 +1,224 @@
+{
+  "SchemeID": "Scheme-113d44fd",
+  "Name": "All Locations Baseline Government Role",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_s01e01.json
+++ b/code_schemes/all_locations_s01e01.json
@@ -1,0 +1,336 @@
+{
+  "SchemeID": "Scheme-97b32732",
+  "Name": "All Locations S01E01",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-ccecbbd4",
+      "CodeType": "Normal",
+      "DisplayText": "educate the community",
+      "NumericValue": 1,
+      "StringValue": "educate_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-1258bcf6",
+      "CodeType": "Normal",
+      "DisplayText": "community lacks knowledge",
+      "NumericValue": 2,
+      "StringValue": "community_lacks_knowledge",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-5ba5788e",
+      "CodeType": "Normal",
+      "DisplayText": "bacteria/virus developed resistance to antimicrobials",
+      "NumericValue": 3,
+      "StringValue": "bacteria_or_virus_developed_resistance_to_antimicrobials",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f6ff7613",
+      "CodeType": "Normal",
+      "DisplayText": "less quality medicines",
+      "NumericValue": 4,
+      "StringValue": "less_quality_medicines",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a2472ece",
+      "CodeType": "Normal",
+      "DisplayText": "should visit hospital",
+      "NumericValue": 5,
+      "StringValue": "should_visit_hospital",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-92da4521",
+      "CodeType": "Normal",
+      "DisplayText": "causes of drug resistance",
+      "NumericValue": 6,
+      "StringValue": "causes_of_drug_resistance",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-4288ce1d",
+      "CodeType": "Normal",
+      "DisplayText": "poor access to hospitals",
+      "NumericValue": 7,
+      "StringValue": "poor_access_to_hospitals",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-4f69d432",
+      "CodeType": "Normal",
+      "DisplayText": "relieves pain",
+      "NumericValue": 8,
+      "StringValue": "relieves_pain",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-4da0fad0",
+      "CodeType": "Normal",
+      "DisplayText": "drug misuse",
+      "NumericValue": 9,
+      "StringValue": "drug_misuse",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-82c9b908",
+      "CodeType": "Normal",
+      "DisplayText": "antibiotics are good",
+      "NumericValue": 10,
+      "StringValue": "antibiotics_are_good",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f7c352f9",
+      "CodeType": "Normal",
+      "DisplayText": "health questions/narratives",
+      "NumericValue": 11,
+      "StringValue": "health_questions_or_narratives",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3da81b29",
+      "CodeType": "Normal",
+      "DisplayText": "the community is aware",
+      "NumericValue": 13,
+      "StringValue": "the_community_is_aware",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-bff4e48c",
+      "CodeType": "Normal",
+      "DisplayText": "amr exists",
+      "NumericValue": 14,
+      "StringValue": "amr_exists",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a2ad09c7",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 12,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_s01e02.json
+++ b/code_schemes/all_locations_s01e02.json
@@ -1,0 +1,225 @@
+{
+  "SchemeID": "Scheme-4ba27da1",
+  "Name": "All Locations S01E02",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_s01e02.json
+++ b/code_schemes/all_locations_s01e02.json
@@ -3,7 +3,94 @@
   "Name": "All Locations S01E02",
   "Version": "0.0.0.1",
   "Codes": [
-
+    {
+      "CodeID": "code-1968050b",
+      "CodeType": "Normal",
+      "DisplayText": "when one is sick/infected",
+      "NumericValue": 1,
+      "StringValue": "when_one_is_sick_or_infected",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-939099b4",
+      "CodeType": "Normal",
+      "DisplayText": "only with prescription",
+      "NumericValue": 2,
+      "StringValue": "only_with_prescription",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a750ff4c",
+      "CodeType": "Normal",
+      "DisplayText": "only in the morning",
+      "NumericValue": 3,
+      "StringValue": "only_in_the_morning",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d7554004",
+      "CodeType": "Normal",
+      "DisplayText": "used anytime to prevent infections",
+      "NumericValue": 4,
+      "StringValue": "used_anytime_to_prevent_infections",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-53797127",
+      "CodeType": "Normal",
+      "DisplayText": "in the morning & evening",
+      "NumericValue": 5,
+      "StringValue": "in_the_morning_and_evening",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d30c41b0",
+      "CodeType": "Normal",
+      "DisplayText": "follow doctor's prescription",
+      "NumericValue": 8,
+      "StringValue": "follow_doctors_prescription",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-bb1bcf58",
+      "CodeType": "Normal",
+      "DisplayText": "community awareness",
+      "NumericValue": 9,
+      "StringValue": "community_awareness",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-1d36eee0",
+      "CodeType": "Normal",
+      "DisplayText": "impact of antimicrobials",
+      "NumericValue": 10,
+      "StringValue": "impact_of_antimicrobials",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-cff22518",
+      "CodeType": "Normal",
+      "DisplayText": "less quality drugs/fake medicines",
+      "NumericValue": 11,
+      "StringValue": "less_quality_drugs_or_fake_medicines",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-80d9988f",
+      "CodeType": "Normal",
+      "DisplayText": "questions",
+      "NumericValue": 6,
+      "StringValue": "questions",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-86e2ff0b",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 7,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
     {
       "CodeID": "code-NA-f93d3eb7",
       "CodeType": "Control",

--- a/code_schemes/all_locations_s01e03.json
+++ b/code_schemes/all_locations_s01e03.json
@@ -1,0 +1,225 @@
+{
+  "SchemeID": "Scheme-233e009a",
+  "Name": "All Locations S01E03",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_s01e04.json
+++ b/code_schemes/all_locations_s01e04.json
@@ -1,0 +1,225 @@
+{
+  "SchemeID": "Scheme-6324979d",
+  "Name": "All Locations S01E04",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/all_locations_s01e05.json
+++ b/code_schemes/all_locations_s01e05.json
@@ -1,0 +1,225 @@
+{
+  "SchemeID": "Scheme-2f8d2e68",
+  "Name": "All Locations S01E05",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-A-a542fb02",
+      "CodeType": "Meta",
+      "MetaCode": "accountability",
+      "DisplayText": "meta: accountability",
+      "NumericValue": -100150,
+      "StringValue": "accountability",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SG-e1f8b4bd",
+      "CodeType": "Meta",
+      "MetaCode": "safeguarding",
+      "DisplayText": "meta: safeguarding",
+      "NumericValue": -100160,
+      "StringValue": "safeguarding",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -7,14 +7,20 @@
       "TokenFileURL": "gs://avf-credentials/gpsdd-kilifi-textit-token.txt",
       "ContactsFileName": "gpsdd_kilifi_contacts",
       "ActivationFlowNames": [
-        "gpsdd_kilifi_s01e01_activation"
+        "gpsdd_kilifi_s01e01_activation",
+        "gpsdd_kilifi_s01e02_activation",
+        "gpsdd_kilifi_s01e03_activation",
+        "gpsdd_kilifi_s01e04_activation"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kilifi_s01_demog"
+        "gpsdd_kilifi_s01_demog",
+        "gpsdd_kilifi_s01_baseline"
       ],
       "TestContactUUIDs": [
-        "40b2747e-764a-4635-b922-6c67c7327075",
-        "fb7dc7b9-403d-4420-895a-dd32aac6ada2"
+        "64918562-d983-4dce-8aa0-91df2879e10b",
+        "96716fa6-7ab6-431e-aa87-54eff239b62c",
+        "e1442557-4c37-4da3-8a92-19fdb044880b",
+        "f471956a-33d9-499e-ba13-eb374f791a99"
       ]
     },
     {
@@ -23,14 +29,21 @@
       "TokenFileURL": "gs://avf-credentials/gpsdd-kiambu-textit-token.txt",
       "ContactsFileName": "gpsdd_kiambu_contacts",
       "ActivationFlowNames": [
-        "gpsdd_kiambu_s01e01_activation"
+        "gpsdd_kiambu_s01e01_activation",
+        "gpsdd_kiambu_s01e02_activation",
+        "gpsdd_kiambu_s01e03_activation",
+        "gpsdd_kiambu_s01e04_activation"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kiambu_s01_demog"
+        "gpsdd_kiambu_s01_demog",
+        "gpsdd_kiambu_s01_baseline"
       ],
       "TestContactUUIDs": [
-        "40b2747e-764a-4635-b922-6c67c7327075",
-        "fb7dc7b9-403d-4420-895a-dd32aac6ada2"
+        "0793361d-c2cb-4a46-89ed-40ef05f5fa4f",
+        "89f1c969-777f-4f55-a3ec-cb49cc9c41cd",
+        "0d3e63a4-e5a6-4c85-ad4f-643e96203a3f",
+        "1dbecf30-a0d9-4005-ae96-099cf40ecb84",
+        "7dfacafd-2b66-43c5-83b7-6c744f1e9a84"
       ]
     },
     {
@@ -39,14 +52,22 @@
       "TokenFileURL": "gs://avf-credentials/gpsdd-bungoma-textit-token.txt",
       "ContactsFileName": "gpsdd_bungoma_contacts",
       "ActivationFlowNames": [
-        "gpsdd_bungoma_s01e01_activation"
+        "gpsdd_bungoma_s01e01_activation",
+        "gpsdd_bungoma_s01e02_activation",
+        "gpsdd_bungoma_s01e03_activation",
+        "gpsdd_bungoma_s01e04_activation"
       ],
       "SurveyFlowNames": [
-        "gpsdd_bungoma_s01_demog"
+        "gpsdd_bungoma_s01_demog",
+        "gpsdd_bungoma_s01_baseline"
       ],
       "TestContactUUIDs": [
         "40b2747e-764a-4635-b922-6c67c7327075",
-        "fb7dc7b9-403d-4420-895a-dd32aac6ada2"
+        "fb7dc7b9-403d-4420-895a-dd32aac6ada2",
+        "d1623047-99c1-4137-9601-8d61ba4ffdf6",
+        "c323751f-49aa-46e4-8d36-3e60e8b90e68",
+        "e38e7423-66c1-43a3-8690-af12b6faf712",
+        "11c54f2a-e842-4a38-ba1d-6af8664ef728"
       ]
     }
   ],
@@ -148,7 +169,22 @@
     {"RapidProKey": "Age (Text) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_age_raw"},
     {"RapidProKey": "Age (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_age_time"},
     {"RapidProKey": "Disabled (Text) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_raw"},
-    {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"}
+    {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
+
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"},
+
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"},
+
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -20,7 +20,9 @@
         "40b2747e-764a-4635-b922-6c67c7327075",
         "fb7dc7b9-403d-4420-895a-dd32aac6ada2",
         "d1623047-99c1-4137-9601-8d61ba4ffdf6",
-        "c323751f-49aa-46e4-8d36-3e60e8b90e68"
+        "c323751f-49aa-46e4-8d36-3e60e8b90e68",
+        "e38e7423-66c1-43a3-8690-af12b6faf712",
+        "11c54f2a-e842-4a38-ba1d-6af8664ef728"
       ]
     }
   ],
@@ -66,10 +68,10 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "baseline_community_awareness_raw"},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "baseline_government_role_raw"},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "baseline_government_role_time"}
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -28,6 +28,12 @@ class CodeSchemes(object):
     BUNGOMA_S01E04 = _open_scheme("bungoma_s01e04.json")
     BUNGOMA_S01E05 = _open_scheme("bungoma_s01e05.json")
 
+    ALL_LOCATIONS_S01E01 = _open_scheme("all_locations_s01e01.json")
+    ALL_LOCATIONS_S01E02 = _open_scheme("all_locations_s01e02.json")
+    ALL_LOCATIONS_S01E03 = _open_scheme("all_locations_s01e03.json")
+    ALL_LOCATIONS_S01E04 = _open_scheme("all_locations_s01e04.json")
+    ALL_LOCATIONS_S01E05 = _open_scheme("all_locations_s01e05.json")
+
     KENYA_CONSTITUENCY = _open_scheme("kenya_constituency.json")
     KENYA_COUNTY = _open_scheme("kenya_county.json")
     GENDER = _open_scheme("gender.json")
@@ -43,5 +49,8 @@ class CodeSchemes(object):
 
     BUNGOMA_BASELINE_COMMUNITY_AWARENESS = _open_scheme("bungoma_baseline_community_awareness.json")
     BUNGOMA_BASELINE_GOVERNMENT_ROLE = _open_scheme("bungoma_baseline_government_role.json")
+
+    ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS = _open_scheme("all_locations_baseline_community_awareness.json")
+    ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE = _open_scheme("all_locations_baseline_government_role.json")
 
     WS_CORRECT_DATASET = _open_scheme("ws_correct_dataset.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -821,7 +821,7 @@ BUNGOMA_FOLLOW_UP_CODING_PLANS = [
                        code_scheme=CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE,
                        coded_field="bungoma_baseline_government_role_coded",
                        analysis_file_key="bungoma_baseline_government_role",
-                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE)
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -31,8 +31,8 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_S01E01,
-                       coded_field="rqa_s01e01_coded",
-                       analysis_file_key="rqa_s01e01",
+                       coded_field="kilifi_rqa_s01e01_coded",
+                       analysis_file_key="kilifi_rqa_s01e01",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KILIFI_S01E01, x, y)
                    )
                ],
@@ -49,8 +49,8 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_S01E02,
-                       coded_field="rqa_s01e02_coded",
-                       analysis_file_key="rqa_s01e02",
+                       coded_field="kilifi_rqa_s01e02_coded",
+                       analysis_file_key="kilifi_rqa_s01e02",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KILIFI_S01E02, x, y)
                    )
                ],
@@ -67,8 +67,8 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_S01E03,
-                       coded_field="rqa_s01e03_coded",
-                       analysis_file_key="rqa_s01e03",
+                       coded_field="kilifi_rqa_s01e03_coded",
+                       analysis_file_key="kilifi_rqa_s01e03",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KILIFI_S01E03, x, y)
                    )
                ],
@@ -85,8 +85,8 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_S01E04,
-                       coded_field="rqa_s01e04_coded",
-                       analysis_file_key="rqa_s01e04",
+                       coded_field="kilifi_rqa_s01e04_coded",
+                       analysis_file_key="kilifi_rqa_s01e04",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KILIFI_S01E04, x, y)
                    )
                ],
@@ -103,8 +103,8 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_S01E05,
-                       coded_field="rqa_s01e05_coded",
-                       analysis_file_key="rqa_s01e05",
+                       coded_field="kilifi_rqa_s01e05_coded",
+                       analysis_file_key="kilifi_rqa_s01e05",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KILIFI_S01E05, x, y)
                    )
                ],
@@ -123,8 +123,8 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_S01E01,
-                       coded_field="rqa_s01e01_coded",
-                       analysis_file_key="rqa_s01e01",
+                       coded_field="kiambu_rqa_s01e01_coded",
+                       analysis_file_key="kiambu_rqa_s01e01",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KIAMBU_S01E01, x, y)
                    )
                ],
@@ -141,8 +141,8 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_S01E02,
-                       coded_field="rqa_s01e02_coded",
-                       analysis_file_key="rqa_s01e02",
+                       coded_field="kiambu_rqa_s01e02_coded",
+                       analysis_file_key="kiambu_rqa_s01e02",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KIAMBU_S01E02, x, y)
                    )
                ],
@@ -159,8 +159,8 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_S01E03,
-                       coded_field="rqa_s01e03_coded",
-                       analysis_file_key="rqa_s01e03",
+                       coded_field="kiambu_rqa_s01e03_coded",
+                       analysis_file_key="kiambu_rqa_s01e03",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KIAMBU_S01E03, x, y)
                    )
                ],
@@ -177,8 +177,8 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_S01E05,
-                       coded_field="rqa_s01e04_coded",
-                       analysis_file_key="rqa_s01e04",
+                       coded_field="kiambu_rqa_s01e04_coded",
+                       analysis_file_key="kiambu_rqa_s01e04",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KIAMBU_S01E05, x, y)
                    )
                ],
@@ -195,8 +195,8 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_S01E05,
-                       coded_field="rqa_s01e05_coded",
-                       analysis_file_key="rqa_s01e05",
+                       coded_field="kiambu_rqa_s01e05_coded",
+                       analysis_file_key="kiambu_rqa_s01e05",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KIAMBU_S01E05, x, y)
                    )
                ],
@@ -215,8 +215,8 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.BUNGOMA_S01E01,
-                       coded_field="rqa_s01e01_coded",
-                       analysis_file_key="rqa_s01e01",
+                       coded_field="bungoma_rqa_s01e01_coded",
+                       analysis_file_key="bungoma_rqa_s01e01",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BUNGOMA_S01E01, x, y)
                    )
                ],
@@ -233,8 +233,8 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.BUNGOMA_S01E02,
-                       coded_field="rqa_s01e02_coded",
-                       analysis_file_key="rqa_s01e02",
+                       coded_field="bungoma_rqa_s01e02_coded",
+                       analysis_file_key="bungoma_rqa_s01e02",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BUNGOMA_S01E02, x, y)
                    )
                ],
@@ -251,8 +251,8 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.BUNGOMA_S01E03,
-                       coded_field="rqa_s01e03_coded",
-                       analysis_file_key="rqa_s01e03",
+                       coded_field="bungoma_rqa_s01e03_coded",
+                       analysis_file_key="bungoma_rqa_s01e03",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BUNGOMA_S01E03, x, y)
                    )
                ],
@@ -269,8 +269,8 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.BUNGOMA_S01E04,
-                       coded_field="rqa_s01e04_coded",
-                       analysis_file_key="rqa_s01e04",
+                       coded_field="bungoma_rqa_s01e04_coded",
+                       analysis_file_key="bungoma_rqa_s01e04",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BUNGOMA_S01E04, x, y)
                    )
                ],
@@ -287,8 +287,8 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.BUNGOMA_S01E05,
-                       coded_field="rqa_s01e05_coded",
-                       analysis_file_key="rqa_s01e05",
+                       coded_field="bungoma_rqa_s01e05_coded",
+                       analysis_file_key="bungoma_rqa_s01e05",
                        fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.BUNGOMA_S01E05, x, y)
                    )
                ],
@@ -296,7 +296,90 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate)
 ]
 
-def get_rqa_coding_plans(pipeline_name):
+ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
+    CodingPlan(raw_field="rqa_s01e01_raw",
+               time_field="sent_on",
+               listening_group_filename="s01e01_listening_group.csv",
+               run_id_field="rqa_s01e01_run_id",
+               icr_filename="s01e01.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.ALL_LOCATIONS_S01E01,
+                       coded_field="rqa_s01e01_coded",
+                       analysis_file_key="rqa_s01e01",
+                       fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.ALL_LOCATIONS_S01E01, x, y)
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+
+    CodingPlan(raw_field="rqa_s01e02_raw",
+               time_field="sent_on",
+               listening_group_filename="s01e02_listening_group.csv",
+               run_id_field="rqa_s01e02_run_id",
+               icr_filename="s01e02.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.ALL_LOCATIONS_S01E02,
+                       coded_field="rqa_s01e02_coded",
+                       analysis_file_key="rqa_s01e02",
+                       fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.ALL_LOCATIONS_S01E02, x, y)
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+    
+    CodingPlan(raw_field="rqa_s01e03_raw",
+               time_field="sent_on",
+               listening_group_filename="s01e03_listening_group.csv",
+               run_id_field="rqa_s01e03_run_id",
+               icr_filename="s01e03.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.ALL_LOCATIONS_S01E03,
+                       coded_field="rqa_s01e03_coded",
+                       analysis_file_key="rqa_s01e03",
+                       fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.ALL_LOCATIONS_S01E03, x, y)
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+    
+    CodingPlan(raw_field="rqa_s01e04_raw",
+               time_field="sent_on",
+               listening_group_filename="s01e04_listening_group.csv",
+               run_id_field="rqa_s01e04_run_id",
+               icr_filename="s01e04.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.ALL_LOCATIONS_S01E04,
+                       coded_field="rqa_s01e04_coded",
+                       analysis_file_key="rqa_s01e04",
+                       fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.ALL_LOCATIONS_S01E04, x, y)
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+    
+    CodingPlan(raw_field="rqa_s01e05_raw",
+               time_field="sent_on",
+               listening_group_filename="s01e05_listening_group.csv",
+               run_id_field="rqa_s01e05_run_id",
+               icr_filename="s01e05.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.ALL_LOCATIONS_S01E05,
+                       coded_field="rqa_s01e05_coded",
+                       analysis_file_key="rqa_s01e05",
+                       fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.ALL_LOCATIONS_S01E05, x, y)
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+]
+
+
+def get_rqa_coding_plans(pipeline_name, analysis_mode=False):
     if pipeline_name == "gpsdd_kilifi_s01_pipeline":
         return KILIFI_S01_RQA_CODING_PLANS
 
@@ -307,7 +390,10 @@ def get_rqa_coding_plans(pipeline_name):
         return BUNGOMA_S01_RQA_CODING_PLANS
 
     elif pipeline_name == "gpsdd_all_locations_s01_pipeline":
-        return KIAMBU_S01_RQA_CODING_PLANS + KILIFI_S01_RQA_CODING_PLANS + BUNGOMA_S01_RQA_CODING_PLANS
+        if not analysis_mode:
+            return KIAMBU_S01_RQA_CODING_PLANS + KILIFI_S01_RQA_CODING_PLANS + BUNGOMA_S01_RQA_CODING_PLANS
+        else:
+            return ALL_LOCATIONS_S01_RQA_CODING_PLANS
 
 
 KILIFI_DEMOG_CODING_PLANS = [
@@ -319,8 +405,8 @@ KILIFI_DEMOG_CODING_PLANS = [
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.GENDER,
                        cleaner=somali.DemographicCleaner.clean_gender,
-                       coded_field="gender_coded",
-                       analysis_file_key="gender",
+                       coded_field="kilifi_gender_coded",
+                       analysis_file_key="kilifi_gender",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -335,16 +421,16 @@ KILIFI_DEMOG_CODING_PLANS = [
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.AGE,
                        cleaner=clean_age_with_range_filter,
-                       coded_field="age_coded",
-                       analysis_file_key="age",
+                       coded_field="kilifi_age_coded",
+                       analysis_file_key="kilifi_age",
                        include_in_theme_distribution=Codes.FALSE,
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    ),
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.AGE_CATEGORY,
-                       coded_field="age_category_coded",
-                       analysis_file_key="age_category",
+                       coded_field="kilifi_age_category_coded",
+                       analysis_file_key="kilifi_age_category",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -359,15 +445,15 @@ KILIFI_DEMOG_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KENYA_COUNTY,
-                       coded_field="county_coded",
-                       analysis_file_key="county",
+                       coded_field="kilifi_county_coded",
+                       analysis_file_key="kilifi_county",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    ),
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KENYA_CONSTITUENCY,
-                       coded_field="constituency_coded",
-                       analysis_file_key="constituency",
+                       coded_field="kilifi_constituency_coded",
+                       analysis_file_key="kilifi_constituency",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -382,8 +468,8 @@ KILIFI_DEMOG_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.DISABLED,
-                       coded_field="disabled_coded",
-                       analysis_file_key="disabled_gender",
+                       coded_field="kilifi_disabled_coded",
+                       analysis_file_key="kilifi_disabled",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -400,8 +486,8 @@ KIAMBU_DEMOG_CODING_PLANS = [
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.GENDER,
                        cleaner=somali.DemographicCleaner.clean_gender,
-                       coded_field="gender_coded",
-                       analysis_file_key="gender",
+                       coded_field="kiambu_gender_coded",
+                       analysis_file_key="kiambu_gender",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -416,16 +502,16 @@ KIAMBU_DEMOG_CODING_PLANS = [
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.AGE,
                        cleaner=clean_age_with_range_filter,
-                       coded_field="age_coded",
-                       analysis_file_key="age",
+                       coded_field="kiambu_age_coded",
+                       analysis_file_key="kiambu_age",
                        include_in_theme_distribution=Codes.FALSE,
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    ),
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.AGE_CATEGORY,
-                       coded_field="age_category_coded",
-                       analysis_file_key="age_category",
+                       coded_field="kiambu_age_category_coded",
+                       analysis_file_key="kiambu_age_category",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -440,15 +526,15 @@ KIAMBU_DEMOG_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KENYA_COUNTY,
-                       coded_field="county_coded",
-                       analysis_file_key="county",
+                       coded_field="kiambu_county_coded",
+                       analysis_file_key="kiambu_county",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    ),
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KENYA_CONSTITUENCY,
-                       coded_field="constituency_coded",
-                       analysis_file_key="constituency",
+                       coded_field="kiambu_constituency_coded",
+                       analysis_file_key="kiambu_constituency",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -463,8 +549,8 @@ KIAMBU_DEMOG_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.DISABLED,
-                       coded_field="disabled_coded",
-                       analysis_file_key="disabled_gender",
+                       coded_field="kiambu_disabled_coded",
+                       analysis_file_key="kiambu_disabled",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -481,8 +567,8 @@ BUNGOMA_DEMOG_CODING_PLANS = [
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.GENDER,
                        cleaner=somali.DemographicCleaner.clean_gender,
-                       coded_field="gender_coded",
-                       analysis_file_key="gender",
+                       coded_field="bungoma_gender_coded",
+                       analysis_file_key="bungoma_gender",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -492,6 +578,84 @@ BUNGOMA_DEMOG_CODING_PLANS = [
     CodingPlan(raw_field="bungoma_age_raw",
                time_field="bungoma_age_time",
                coda_filename="GPSDD_BUNGOMA_age.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.AGE,
+                       cleaner=clean_age_with_range_filter,
+                       coded_field="bungoma_age_coded",
+                       analysis_file_key="bungoma_age",
+                       include_in_theme_distribution=Codes.FALSE,
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   ),
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.AGE_CATEGORY,
+                       coded_field="bungoma_age_category_coded",
+                       analysis_file_key="bungoma_age_category",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               code_imputation_function=code_imputation_functions.impute_age_category,
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma age"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="bungoma_location_raw",
+               time_field="bungoma_location_time",
+               coda_filename="GPSDD_BUNGOMA_location.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.KENYA_COUNTY,
+                       coded_field="bungoma_county_coded",
+                       analysis_file_key="bungoma_county",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   ),
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.KENYA_CONSTITUENCY,
+                       coded_field="bungoma_constituency_coded",
+                       analysis_file_key="bungoma_constituency",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               code_imputation_function=code_imputation_functions.impute_kenya_location_codes,
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma location"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="bungoma_disabled_raw",
+               time_field="bungoma_disabled_time",
+               coda_filename="GPSDD_BUNGOMA_disabled.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.DISABLED,
+                       coded_field="bungoma_disabled_coded",
+                       analysis_file_key="bungoma_disabled",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma disabled"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal)
+]
+
+ALL_LOCATIONS_DEMOG_CODING_PLANS = [
+    CodingPlan(raw_field="gender_raw",
+               time_field="gender_time",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.GENDER,
+                       cleaner=somali.DemographicCleaner.clean_gender,
+                       coded_field="gender_coded",
+                       analysis_file_key="gender",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="age_raw",
+               time_field="age_time",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
@@ -511,12 +675,10 @@ BUNGOMA_DEMOG_CODING_PLANS = [
                    )
                ],
                code_imputation_function=code_imputation_functions.impute_age_category,
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma age"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
-    CodingPlan(raw_field="bungoma_location_raw",
-               time_field="bungoma_location_time",
-               coda_filename="GPSDD_BUNGOMA_location.json",
+    CodingPlan(raw_field="location_raw",
+               time_field="location_time",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
@@ -534,26 +696,24 @@ BUNGOMA_DEMOG_CODING_PLANS = [
                    )
                ],
                code_imputation_function=code_imputation_functions.impute_kenya_location_codes,
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma location"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
-    CodingPlan(raw_field="bungoma_disabled_raw",
-               time_field="bungoma_disabled_time",
-               coda_filename="GPSDD_BUNGOMA_disabled.json",
+    CodingPlan(raw_field="disabled_raw",
+               time_field="disabled_time",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.DISABLED,
                        coded_field="disabled_coded",
-                       analysis_file_key="disabled_gender",
+                       analysis_file_key="disabled",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma disabled"),
                raw_field_fold_strategy=FoldStrategies.assert_equal)
 ]
 
-def get_demog_coding_plans(pipeline_name):
+
+def get_demog_coding_plans(pipeline_name, analysis_mode=False):
     if pipeline_name == "gpsdd_kilifi_s01_pipeline":
         return KILIFI_DEMOG_CODING_PLANS
 
@@ -564,34 +724,37 @@ def get_demog_coding_plans(pipeline_name):
         return BUNGOMA_DEMOG_CODING_PLANS
 
     elif pipeline_name == "gpsdd_all_locations_s01_pipeline":
-        return KILIFI_DEMOG_CODING_PLANS + KIAMBU_DEMOG_CODING_PLANS + BUNGOMA_DEMOG_CODING_PLANS
+        if not analysis_mode:
+            return KILIFI_DEMOG_CODING_PLANS + KIAMBU_DEMOG_CODING_PLANS + BUNGOMA_DEMOG_CODING_PLANS
+        else:
+            return ALL_LOCATIONS_DEMOG_CODING_PLANS
 
 
 KILIFI_FOLLOW_UP_CODING_PLANS = [
-    CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
+    CodingPlan(raw_field="kilifi_baseline_community_awareness_raw",
+               time_field="kilifi_baseline_community_awareness_time",
                coda_filename="GPSDD_KILIFI_baseline_community_awareness.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KILIFI_BASELINE_COMMUNITY_AWARENESS,
-                       coded_field="baseline_community_awareness_coded",
-                       analysis_file_key="baseline_community_awareness",
+                       coded_field="kilifi_baseline_community_awareness_coded",
+                       analysis_file_key="kilifi_baseline_community_awareness",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
-    CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
+    CodingPlan(raw_field="kilifi_baseline_government_role_raw",
+               time_field="kilifi_baseline_government_role_time",
                coda_filename="GPSDD_KILIFI_baseline_government_role.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KILIFI_BASELINE_GOVERNMENT_ROLE,
-                       coded_field="baseline_government_role_coded",
-                       analysis_file_key="baseline_government_role",
+                       coded_field="kilifi_baseline_government_role_coded",
+                       analysis_file_key="kilifi_baseline_government_role",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -600,30 +763,30 @@ KILIFI_FOLLOW_UP_CODING_PLANS = [
 ]
 
 KIAMBU_FOLLOW_UP_CODING_PLANS = [
-    CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
+    CodingPlan(raw_field="kiambu_baseline_community_awareness_raw",
+               time_field="kiambu_baseline_community_awareness_time",
                coda_filename="GPSDD_KIAMBU_baseline_community_awareness.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KIAMBU_BASELINE_COMMUNITY_AWARENESS,
-                       coded_field="baseline_community_awareness_coded",
-                       analysis_file_key="baseline_community_awareness",
+                       coded_field="kiambu_baseline_community_awareness_coded",
+                       analysis_file_key="kiambu_baseline_community_awareness",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kiambu baseline community awareness"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
-    CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
+    CodingPlan(raw_field="kiambu_baseline_government_role_raw",
+               time_field="kiambu_baseline_government_role_time",
                coda_filename="GPSDD_KIAMBU_baseline_government_role.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KIAMBU_BASELINE_GOVERNMENT_ROLE,
-                       coded_field="baseline_government_role_coded",
-                       analysis_file_key="baseline_government_role",
+                       coded_field="kiambu_baseline_government_role_coded",
+                       analysis_file_key="kiambu_baseline_government_role",
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
@@ -632,9 +795,40 @@ KIAMBU_FOLLOW_UP_CODING_PLANS = [
 ]
 
 BUNGOMA_FOLLOW_UP_CODING_PLANS = [
+    CodingPlan(raw_field="bungoma_baseline_community_awareness_raw",
+               time_field="bungoma_baseline_community_awareness_time",
+               coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_COMMUNITY_AWARENESS,
+                       coded_field="bungoma_baseline_community_awareness_coded",
+                       analysis_file_key="bungoma_baseline_community_awareness",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="bungoma_baseline_government_role_raw",
+               time_field="bungoma_baseline_government_role_time",
+               coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE,
+                       coded_field="bungoma_baseline_government_role_coded",
+                       analysis_file_key="bungoma_baseline_government_role",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+]
+
+ALL_LOCATIONS_FOLLOW_UP_CODING_PLANS = [
     CodingPlan(raw_field="baseline_community_awareness_raw",
                time_field="baseline_community_awareness_time",
-               coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
@@ -644,12 +838,10 @@ BUNGOMA_FOLLOW_UP_CODING_PLANS = [
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
     CodingPlan(raw_field="baseline_government_role_raw",
                time_field="baseline_government_role_time",
-               coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
@@ -659,12 +851,11 @@ BUNGOMA_FOLLOW_UP_CODING_PLANS = [
                        fold_strategy=FoldStrategies.assert_label_ids_equal
                    )
                ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 ]
 
 
-def get_follow_up_coding_plans(pipeline_name):
+def get_follow_up_coding_plans(pipeline_name, analysis_mode=False):
     if pipeline_name == "gpsdd_kilifi_s01_pipeline":
         return KILIFI_FOLLOW_UP_CODING_PLANS
     elif pipeline_name == "gpsdd_kiambu_s01_pipeline":
@@ -672,7 +863,10 @@ def get_follow_up_coding_plans(pipeline_name):
     elif pipeline_name == "gpsdd_bungoma_s01_pipeline":
         return BUNGOMA_FOLLOW_UP_CODING_PLANS
     elif pipeline_name == "gpsdd_all_locations_s01_pipeline":
-        return KILIFI_FOLLOW_UP_CODING_PLANS + KIAMBU_FOLLOW_UP_CODING_PLANS + BUNGOMA_FOLLOW_UP_CODING_PLANS
+        if not analysis_mode:
+            return KILIFI_FOLLOW_UP_CODING_PLANS + KIAMBU_FOLLOW_UP_CODING_PLANS + BUNGOMA_FOLLOW_UP_CODING_PLANS
+        else:
+            return ALL_LOCATIONS_FOLLOW_UP_CODING_PLANS
     else:
         assert False, f"PipelineName {pipeline_name} not recognized"
 

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -18,7 +18,10 @@
       ],
       "TestContactUUIDs": [
         "0793361d-c2cb-4a46-89ed-40ef05f5fa4f",
-        "89f1c969-777f-4f55-a3ec-cb49cc9c41cd"
+        "89f1c969-777f-4f55-a3ec-cb49cc9c41cd",
+        "0d3e63a4-e5a6-4c85-ad4f-643e96203a3f",
+        "1dbecf30-a0d9-4005-ae96-099cf40ecb84",
+        "7dfacafd-2b66-43c5-83b7-6c744f1e9a84"
       ]
     }
   ],
@@ -64,12 +67,12 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_kiambu_s01_demog", "PipelineKey": "kiambu_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_kiambu_s01_demog", "PipelineKey": "kiambu_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "baseline_community_awareness_raw"},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "baseline_government_role_raw"},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "baseline_government_role_time"}
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"}
   ],
-  "ProjectStartDate": "2021-02-01T10:30:00+03:00",
+  "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",
   "FilterTestMessages": true,
   "MoveWSMessages": true,

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -19,7 +19,8 @@
       "TestContactUUIDs": [
         "64918562-d983-4dce-8aa0-91df2879e10b",
         "96716fa6-7ab6-431e-aa87-54eff239b62c",
-        "e1442557-4c37-4da3-8a92-19fdb044880b"
+        "e1442557-4c37-4da3-8a92-19fdb044880b",
+        "f471956a-33d9-499e-ba13-eb374f791a99"
       ]
     }
   ],
@@ -65,10 +66,10 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_kilifi_s01_demog", "PipelineKey": "kilifi_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_kilifi_s01_demog", "PipelineKey": "kilifi_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "baseline_community_awareness_raw"},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "baseline_government_role_raw"},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "baseline_government_role_time"}
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -1,9 +1,17 @@
 import argparse
+from copy import deepcopy
+from functools import partial
 
+from core_data_modules.analysis import analysis_utils, AnalysisConfiguration
 from core_data_modules.logging import Logger
+from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataJsonIO
-from core_data_modules.util import IOUtils
+from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
+from core_data_modules.util import IOUtils, TimeUtils
 
+from configuration.code_schemes import CodeSchemes
+from configuration.coding_plans import get_rqa_coding_plans, get_demog_coding_plans, get_follow_up_coding_plans, \
+    BUNGOMA_S01_RQA_CODING_PLANS, KILIFI_S01_RQA_CODING_PLANS, KIAMBU_S01_RQA_CODING_PLANS
 from src import LoadData, TranslateRapidProKeys, AutoCode, ProductionFile, \
     ApplyManualCodes, AnalysisFile, WSCorrection
 from src.lib import PipelineConfiguration, MessageFilters
@@ -102,6 +110,148 @@ if __name__ == "__main__":
 
         log.info("Applying Manual Codes from Coda...")
         data = ApplyManualCodes.apply_manual_codes(user, data, prev_coded_dir_path)
+
+        if pipeline_configuration.pipeline_name == "gpsdd_all_locations_s01_pipeline":
+            # Up to this point the pipeline has run as normal, keeping data separate by location.
+            # Now, we need to produce analysis files that cover all locations, which requires combining the datasets into
+            # one. This is very difficult, because the pipeline assumed that there would be one raw field and one coda
+            # dataset per field.
+            # We now have to patch up this dataset:
+
+            # 1. Change the coding plans to refer to ones that contain unified field names and code schemes etc. rather
+            # than per-location
+            PipelineConfiguration.RQA_CODING_PLANS = get_rqa_coding_plans(pipeline_configuration.pipeline_name, True)
+            PipelineConfiguration.DEMOG_CODING_PLANS = get_demog_coding_plans(pipeline_configuration.pipeline_name, True)
+            PipelineConfiguration.FOLLOW_UP_CODING_PLANS = get_follow_up_coding_plans(pipeline_configuration.pipeline_name, True)
+            PipelineConfiguration.SURVEY_CODING_PLANS = PipelineConfiguration.DEMOG_CODING_PLANS + PipelineConfiguration.FOLLOW_UP_CODING_PLANS
+
+            # 2. Patch up all the labels' scheme ids to refer to the relevant 'all_locations' scheme rather than to
+            # the individual location schemes.
+            rqa_scheme_remaps = {
+                "kilifi_rqa_s01e01_coded": CodeSchemes.ALL_LOCATIONS_S01E01,
+                "kiambu_rqa_s01e01_coded": CodeSchemes.ALL_LOCATIONS_S01E01,
+                "bungoma_rqa_s01e01_coded": CodeSchemes.ALL_LOCATIONS_S01E01,
+                "kilifi_rqa_s01e02_coded": CodeSchemes.ALL_LOCATIONS_S01E02,
+                "kiambu_rqa_s01e02_coded": CodeSchemes.ALL_LOCATIONS_S01E02,
+                "bungoma_rqa_s01e02_coded": CodeSchemes.ALL_LOCATIONS_S01E02,
+                "kilifi_rqa_s01e03_coded": CodeSchemes.ALL_LOCATIONS_S01E03,
+                "kiambu_rqa_s01e03_coded": CodeSchemes.ALL_LOCATIONS_S01E03,
+                "bungoma_rqa_s01e03_coded": CodeSchemes.ALL_LOCATIONS_S01E03,
+                "kilifi_rqa_s01e04_coded": CodeSchemes.ALL_LOCATIONS_S01E04,
+                "kiambu_rqa_s01e04_coded": CodeSchemes.ALL_LOCATIONS_S01E04,
+                "bungoma_rqa_s01e04_coded": CodeSchemes.ALL_LOCATIONS_S01E04,
+                "kilifi_rqa_s01e05_coded": CodeSchemes.ALL_LOCATIONS_S01E05,
+                "kiambu_rqa_s01e05_coded": CodeSchemes.ALL_LOCATIONS_S01E05,
+                "bungoma_rqa_s01e05_coded": CodeSchemes.ALL_LOCATIONS_S01E05
+            }
+
+            for td in data:
+                remapped = dict()
+                for field, target_scheme in rqa_scheme_remaps.items():
+                    labels = deepcopy(td[field])
+                    for l in labels:
+                        l["SchemeID"] = target_scheme.scheme_id
+                    remapped[field] = labels
+                td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+            # 3. Convert the fields in the bungoma/kilifi/kiambu coding plans relevant to analysis to their unified
+            # fields. This is mostly like folding messages -> individuals, except we now have to account for some fields
+            # being None, which is why there are some special case strategies implemented inline here.
+            def assert_equal(x, y):
+                if x is None:
+                    return y
+                if y is None:
+                    return x
+
+                assert x == y, f"{x} != {y}"
+                return x
+
+
+            def demog_labels(code_scheme, x, y):
+                if code_scheme.get_code_with_code_id(x["CodeID"]).control_code == "NA":
+                    return y
+                if code_scheme.get_code_with_code_id(y["CodeID"]).control_code == "NA":
+                    return x
+
+                assert x["CodeID"] == y["CodeID"]
+                return x
+
+            remappings = {
+                "rqa_s01e01_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_S01E01),
+                "rqa_s01e02_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_S01E02),
+                "rqa_s01e03_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_S01E03),
+                "rqa_s01e04_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_S01E04),
+                "rqa_s01e05_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_S01E05),
+
+                "rqa_s01e01_raw": FoldStrategies.concatenate,
+                "rqa_s01e02_raw": FoldStrategies.concatenate,
+                "rqa_s01e03_raw": FoldStrategies.concatenate,
+                "rqa_s01e04_raw": FoldStrategies.concatenate,
+                "rqa_s01e05_raw": FoldStrategies.concatenate,
+
+                "gender_coded": partial(demog_labels, CodeSchemes.GENDER),
+                "age_coded": partial(demog_labels, CodeSchemes.AGE),
+                "age_category_coded": partial(demog_labels, CodeSchemes.AGE_CATEGORY),
+                "county_coded": partial(demog_labels, CodeSchemes.KENYA_COUNTY),
+                "constituency_coded": partial(demog_labels, CodeSchemes.KENYA_CONSTITUENCY),
+                "disabled_coded": partial(demog_labels, CodeSchemes.DISABLED),
+
+                "gender_raw": assert_equal,
+                "age_raw": assert_equal,
+                "location_raw": assert_equal,
+                "disabled_raw": assert_equal,
+
+                "baseline_community_awareness_coded": partial(demog_labels, CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS),
+                "baseline_government_role_coded": partial(demog_labels, CodeSchemes.ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE),
+
+                "baseline_community_awareness_raw": assert_equal,
+                "baseline_government_role_raw": assert_equal
+            }
+
+
+            def coding_plans_to_analysis_configurations(coding_plans):
+                analysis_configurations = []
+                for plan in coding_plans:
+                    ccs = plan.coding_configurations
+                    for cc in ccs:
+                        analysis_configurations.append(
+                            AnalysisConfiguration(cc.analysis_file_key, plan.raw_field, cc.coded_field, cc.code_scheme)
+                        )
+                return analysis_configurations
+
+
+            bungoma_rqa_participants = {td["uid"] for td in
+                                        analysis_utils.filter_opt_ins(data, "uid",
+                                                                      coding_plans_to_analysis_configurations(
+                                                                          BUNGOMA_S01_RQA_CODING_PLANS))}
+            kilifi_rqa_participants = {td["uid"] for td in
+                                       analysis_utils.filter_opt_ins(data, "uid",
+                                                                     coding_plans_to_analysis_configurations(
+                                                                         KILIFI_S01_RQA_CODING_PLANS))}
+            kiambu_rqa_participants = {td["uid"] for td in
+                                       analysis_utils.filter_opt_ins(data, "uid",
+                                                                     coding_plans_to_analysis_configurations(
+                                                                         KIAMBU_S01_RQA_CODING_PLANS))}
+
+            print(len(bungoma_rqa_participants))
+
+            print(bungoma_rqa_participants.intersection(kilifi_rqa_participants))
+            print(bungoma_rqa_participants.intersection(kiambu_rqa_participants))
+            print(kiambu_rqa_participants.intersection(kilifi_rqa_participants))
+
+
+            for td in data:
+                remapped = dict()
+                for field, strategy in remappings.items():
+                    x = td.get(f"kilifi_{field}")
+                    y = td.get(f"kiambu_{field}")
+                    z = td.get(f"bungoma_{field}")
+
+                    folded = strategy(strategy(x, y), z)
+                    if folded is not None:
+                        remapped[field] = folded
+
+                td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
         log.info("Tagging listening group participants & Generating Analysis CSVs...")
         messages_data, individuals_data = AnalysisFile.generate(user, data, pipeline_configuration, raw_data_dir,

--- a/run_scripts/1_all_locations_coda_get.sh
+++ b/run_scripts/1_all_locations_coda_get.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $# -ne 3 ]]; then
-    echo "Usage: ./1_bungoma_coda_get.sh <coda-auth-file> <coda-v2-root> <data-root>"
+    echo "Usage: ./1_all_locations_coda_get.sh <coda-auth-file> <coda-v2-root> <data-root>"
     echo "Downloads coded messages datasets from Coda to '<data-root>/Coded Coda Files'"
     exit
 fi

--- a/run_scripts/1_all_locations_coda_get.sh
+++ b/run_scripts/1_all_locations_coda_get.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: ./1_bungoma_coda_get.sh <coda-auth-file> <coda-v2-root> <data-root>"
+    echo "Downloads coded messages datasets from Coda to '<data-root>/Coded Coda Files'"
+    exit
+fi
+
+AUTH=$1
+CODA_V2_ROOT=$2
+DATA_ROOT=$3
+
+./checkout_coda_v2.sh "$CODA_V2_ROOT"
+
+DATASETS=(
+    "GPSDD_BUNGOMA_s01e01"
+    "GPSDD_BUNGOMA_s01e02"
+    "GPSDD_BUNGOMA_s01e03"
+    "GPSDD_BUNGOMA_s01e04"
+    "GPSDD_BUNGOMA_s01e05"
+
+    "GPSDD_BUNGOMA_age"
+    "GPSDD_BUNGOMA_gender"
+    "GPSDD_BUNGOMA_location"
+    "GPSDD_BUNGOMA_disabled"
+
+    "GPSDD_BUNGOMA_baseline_community_awareness"
+    "GPSDD_BUNGOMA_baseline_government_role"
+
+    "GPSDD_KIAMBU_s01e01"
+    "GPSDD_KIAMBU_s01e02"
+    "GPSDD_KIAMBU_s01e03"
+    "GPSDD_KIAMBU_s01e04"
+    "GPSDD_KIAMBU_s01e05"
+
+    "GPSDD_KIAMBU_age"
+    "GPSDD_KIAMBU_gender"
+    "GPSDD_KIAMBU_location"
+    "GPSDD_KIAMBU_disabled"
+
+    "GPSDD_KIAMBU_baseline_community_awareness"
+    "GPSDD_KIAMBU_baseline_government_role"
+
+    "GPSDD_KILIFI_s01e01"
+    "GPSDD_KILIFI_s01e02"
+    "GPSDD_KILIFI_s01e03"
+    "GPSDD_KILIFI_s01e04"
+    "GPSDD_KILIFI_s01e05"
+
+    "GPSDD_KILIFI_age"
+    "GPSDD_KILIFI_gender"
+    "GPSDD_KILIFI_location"
+    "GPSDD_KILIFI_disabled"
+
+    "GPSDD_KILIFI_baseline_community_awareness"
+    "GPSDD_KILIFI_baseline_government_role"
+)
+
+cd "$CODA_V2_ROOT/data_tools"
+git checkout "c47977d03f96ba3e97c704c967c755f0f8b666cb"  # (master which supports incremental add)
+
+mkdir -p "$DATA_ROOT/Coded Coda Files"
+
+for DATASET in ${DATASETS[@]}
+do
+    FILE="$DATA_ROOT/Coded Coda Files/$DATASET.json"
+
+    if [ -e "$FILE" ]; then
+        echo "Getting messages data from ${DATASET} (incremental update)..."
+        MESSAGES=$(pipenv run python get.py --previous-export-file-path "$FILE" "$AUTH" "${DATASET}" messages)
+        echo "$MESSAGES" >"$FILE"
+    else
+        echo "Getting messages data from ${DATASET} (full download)..."
+        pipenv run python get.py "$AUTH" "${DATASET}" messages >"$FILE"
+    fi
+
+done

--- a/run_scripts/run_all_locations_pipeline.sh
+++ b/run_scripts/run_all_locations_pipeline.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $# -ne 10 ]]; then
-    echo "Usage: ./run_kilifi_pipeline.sh"
+    echo "Usage: ./run_all_locations_pipeline.sh"
     echo "  <user> <pipeline-run-mode> <pipeline-configuration-json>"
     echo "  <coda-pull-credentials-path> <coda-push-credentials-path> <avf-bucket-credentials-path>"
     echo "  <coda-tools-root> <data-root> <data-backup-dir> <performance-logs-dir>"

--- a/run_scripts/run_all_locations_pipeline.sh
+++ b/run_scripts/run_all_locations_pipeline.sh
@@ -28,8 +28,7 @@ RUN_ID="$TIMESTAMP-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunStart"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunStart"
 
 ./1_all_locations_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
@@ -53,5 +52,4 @@ fi
 ./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" \
                         "$DATA_BACKUPS_DIR"
 
-./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
-                        "$TIMESTAMP" "$RUN_ID" "PipelineRunEnd"
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$RUN_ID" "PipelineRunEnd"

--- a/run_scripts/run_all_locations_pipeline.sh
+++ b/run_scripts/run_all_locations_pipeline.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -ne 10 ]]; then
+    echo "Usage: ./run_kilifi_pipeline.sh"
+    echo "  <user> <pipeline-run-mode> <pipeline-configuration-json>"
+    echo "  <coda-pull-credentials-path> <coda-push-credentials-path> <avf-bucket-credentials-path>"
+    echo "  <coda-tools-root> <data-root> <data-backup-dir> <performance-logs-dir>"
+    echo "Runs the pipeline end-to-end (data fetch, coda fetch, output generation, Drive upload, Coda upload, data backup)"
+    exit
+fi
+
+USER=$1
+PIPELINE_RUN_MODE=$2
+PIPELINE_CONFIGURATION=$3
+CODA_PULL_CREDENTIALS_PATH=$4
+CODA_PUSH_CREDENTIALS_PATH=$5
+AVF_BUCKET_CREDENTIALS_PATH=$6
+CODA_TOOLS_ROOT=$7
+DATA_ROOT=$8
+DATA_BACKUPS_DIR=$9
+PERFORMANCE_LOGS_DIR=${10}
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+HASH=$(git rev-parse HEAD)
+RUN_ID="$TIMESTAMP-$HASH"
+
+echo "Starting run with id '$RUN_ID'"
+
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
+                        "$TIMESTAMP" "$RUN_ID" "PipelineRunStart"
+
+./1_all_locations_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+
+./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+
+./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
+    "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+
+# Skipping Coda add in all-locations mode
+
+if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
+   ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" \
+                            "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+fi
+
+./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
+
+./7_upload_analysis_files.sh "$USER" "$PIPELINE_RUN_MODE" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
+    "$RUN_ID" "$DATA_ROOT"
+
+./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" \
+                        "$DATA_BACKUPS_DIR"
+
+./log_pipeline_event.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
+                        "$TIMESTAMP" "$RUN_ID" "PipelineRunEnd"


### PR DESCRIPTION
This was difficult because the pipelines assume that each dataset will only be labelled in one place, and I couldn't see any easy way to convert from those 3 locations into 1. Working under time pressures and the existing infrastructure that had already been deployed, this PR addresses the challenges with a tactical solution that:
 - Adds additional code schemes for each dataset in the all_locations pipeline. These code schemes contain the union of the codes seen in all of the individual location pipelines.
 - Loads each of the location datasets separately at first, and keeps them separate through to the end of apply_manual_codes.
 - Applies a tactical conversion from the individual location datasets into single, all-locations datasets.
 - Changes the coding plans to refer to combined datasets, rather than per-location, then continues as normal using those new coding plans.

I'd be very happy if you could find a cleaner solution, but I think this should be good enough to tide-us over to the end of the project. We can discuss if we're likely to need this in future and think about designing a better solution in the project post-mortem.