### PR TITLE
Treat follow-ups as RQAs

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -158,17 +158,16 @@ if __name__ == "__main__":
             limit_per_code=100
         )
 
-    # TODO: Re-enable once supporting different sent_on_keys and the traffic timestamps are fixed.
-    # if pipeline_configuration.automated_analysis.traffic_labels is not None:
-    #     log.info("Exporting traffic analysis...")
-    #     with open(f"{automated_analysis_output_dir}/traffic_analysis.csv", "w") as f:
-    #         traffic_analysis.export_traffic_analysis_csv(
-    #             messages, CONSENT_WITHDRAWN_KEY,
-    #             coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
-    #             SENT_ON_KEY,
-    #             pipeline_configuration.automated_analysis.traffic_labels,
-    #             f
-    #         )
+    if pipeline_configuration.automated_analysis.traffic_labels is not None:
+        log.info("Exporting traffic analysis...")
+        with open(f"{automated_analysis_output_dir}/traffic_analysis.csv", "w") as f:
+            traffic_analysis.export_traffic_analysis_csv(
+                messages, CONSENT_WITHDRAWN_KEY,
+                coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
+                SENT_ON_KEY,
+                pipeline_configuration.automated_analysis.traffic_labels,
+                f
+            )
 
     # Produce maps of Kenya at county level
     pipeline_name = pipeline_configuration.pipeline_name

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -150,16 +150,17 @@ if __name__ == "__main__":
             limit_per_code=100
         )
 
-    if pipeline_configuration.automated_analysis.traffic_labels is not None:
-        log.info("Exporting traffic analysis...")
-        with open(f"{automated_analysis_output_dir}/traffic_analysis.csv", "w") as f:
-            traffic_analysis.export_traffic_analysis_csv(
-                messages, CONSENT_WITHDRAWN_KEY,
-                coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
-                SENT_ON_KEY,
-                pipeline_configuration.automated_analysis.traffic_labels,
-                f
-            )
+    # TODO: Re-enable once supporting different sent_on_keys and the traffic timestamps are fixed.
+    # if pipeline_configuration.automated_analysis.traffic_labels is not None:
+    #     log.info("Exporting traffic analysis...")
+    #     with open(f"{automated_analysis_output_dir}/traffic_analysis.csv", "w") as f:
+    #         traffic_analysis.export_traffic_analysis_csv(
+    #             messages, CONSENT_WITHDRAWN_KEY,
+    #             coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
+    #             SENT_ON_KEY,
+    #             pipeline_configuration.automated_analysis.traffic_labels,
+    #             f
+    #         )
 
     log.info(f"Exporting participation maps for each Kenya county...")
     participation_maps.export_participation_maps(

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     participation_maps.export_participation_maps(
         individuals, CONSENT_WITHDRAWN_KEY,
         coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
-        AnalysisConfiguration(county_field, "location_raw", "county_coded", CodeSchemes.KENYA_COUNTY),
+        AnalysisConfiguration(county_field, "location_raw", f"{county_field}_coded", CodeSchemes.KENYA_COUNTY),
         kenya_mapper.export_kenya_counties_map,
         f"{automated_analysis_output_dir}/maps/counties/county_",
         export_by_theme=pipeline_configuration.automated_analysis.generate_county_theme_distribution_maps
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     participation_maps.export_participation_maps(
         individuals, CONSENT_WITHDRAWN_KEY,
         coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
-        AnalysisConfiguration(constituency_field, "location_raw", "constituency_coded", CodeSchemes.KENYA_CONSTITUENCY),
+        AnalysisConfiguration(constituency_field, "location_raw", f"{constituency_field}_coded", CodeSchemes.KENYA_CONSTITUENCY),
         kenya_mapper.export_kenya_constituencies_map,
         f"{automated_analysis_output_dir}/maps/constituencies/constituency_",
         export_by_theme=pipeline_configuration.automated_analysis.generate_constituency_theme_distribution_maps

--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -172,19 +172,19 @@
     {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "sent_one"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"},
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "sent_on"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw", "IsActivationMessage": true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
+    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -10,11 +10,11 @@
         "gpsdd_kilifi_s01e01_activation",
         "gpsdd_kilifi_s01e02_activation",
         "gpsdd_kilifi_s01e03_activation",
-        "gpsdd_kilifi_s01e04_activation"
+        "gpsdd_kilifi_s01e04_activation",
+        "gpsdd_kilifi_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kilifi_s01_demog",
-        "gpsdd_kilifi_s01_baseline"
+        "gpsdd_kilifi_s01_demog"
       ],
       "TestContactUUIDs": [
         "64918562-d983-4dce-8aa0-91df2879e10b",
@@ -32,11 +32,11 @@
         "gpsdd_kiambu_s01e01_activation",
         "gpsdd_kiambu_s01e02_activation",
         "gpsdd_kiambu_s01e03_activation",
-        "gpsdd_kiambu_s01e04_activation"
+        "gpsdd_kiambu_s01e04_activation",
+        "gpsdd_kiambu_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kiambu_s01_demog",
-        "gpsdd_kiambu_s01_baseline"
+        "gpsdd_kiambu_s01_demog"
       ],
       "TestContactUUIDs": [
         "0793361d-c2cb-4a46-89ed-40ef05f5fa4f",
@@ -55,11 +55,11 @@
         "gpsdd_bungoma_s01e01_activation",
         "gpsdd_bungoma_s01e02_activation",
         "gpsdd_bungoma_s01e03_activation",
-        "gpsdd_bungoma_s01e04_activation"
+        "gpsdd_bungoma_s01e04_activation",
+        "gpsdd_bungoma_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_bungoma_s01_demog",
-        "gpsdd_bungoma_s01_baseline"
+        "gpsdd_bungoma_s01_demog"
       ],
       "TestContactUUIDs": [
         "40b2747e-764a-4635-b922-6c67c7327075",
@@ -171,19 +171,19 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw", "IsActivationMessage": true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw", "IsActivationMessage": true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw", "IsActivationMessage": true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw", "IsActivationMessage": true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw", "IsActivationMessage": true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw", "IsActivationMessage": true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -10,11 +10,11 @@
         "gpsdd_bungoma_s01e01_activation",
         "gpsdd_bungoma_s01e02_activation",
         "gpsdd_bungoma_s01e03_activation",
-        "gpsdd_bungoma_s01e04_activation"
+        "gpsdd_bungoma_s01e04_activation",
+        "gpsdd_bungoma_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_bungoma_s01_demog",
-        "gpsdd_bungoma_s01_baseline"
+        "gpsdd_bungoma_s01_demog"
       ],
       "TestContactUUIDs": [
         "40b2747e-764a-4635-b922-6c67c7327075",

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -69,9 +69,9 @@
     {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
+    {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -68,9 +68,9 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_bungoma_s01_demog", "PipelineKey": "bungoma_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_bungoma_s01_baseline", "PipelineKey": "bungoma_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -116,9 +116,10 @@ KILIFI_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kilifi_baseline_community_awareness_raw",
                time_field="kilifi_baseline_community_awareness_time",
                coda_filename="GPSDD_KILIFI_baseline_community_awareness.json",
+               icr_filename="kilifi_baseline_community_awareness.csv",
                coding_configurations=[
                    CodingConfiguration(
-                       coding_mode=CodingModes.SINGLE,
+                       coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KILIFI_BASELINE_COMMUNITY_AWARENESS,
                        coded_field="kilifi_baseline_community_awareness_coded",
                        analysis_file_key="kilifi_baseline_community_awareness",
@@ -131,6 +132,7 @@ KILIFI_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kilifi_baseline_government_role_raw",
                time_field="kilifi_baseline_government_role_time",
                coda_filename="GPSDD_KILIFI_baseline_government_role.json",
+               icr_filename="kilifi_baseline_government_role.csv",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
@@ -238,9 +240,10 @@ KIAMBU_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kiambu_baseline_community_awareness_raw",
                time_field="kiambu_baseline_community_awareness_time",
                coda_filename="GPSDD_KIAMBU_baseline_community_awareness.json",
+               icr_filename="kiambu_baseline_community_awareness.csv",
                coding_configurations=[
                    CodingConfiguration(
-                       coding_mode=CodingModes.SINGLE,
+                       coding_mode=CodingModes.MULTIPLE,
                        code_scheme=CodeSchemes.KIAMBU_BASELINE_COMMUNITY_AWARENESS,
                        coded_field="kiambu_baseline_community_awareness_coded",
                        analysis_file_key="kiambu_baseline_community_awareness",
@@ -253,6 +256,7 @@ KIAMBU_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kiambu_baseline_government_role_raw",
                time_field="kiambu_baseline_government_role_time",
                coda_filename="GPSDD_KIAMBU_baseline_government_role.json",
+               icr_filename="kiambu_baseline_government_role.csv",
                coding_configurations=[
                    CodingConfiguration(
                        coding_mode=CodingModes.MULTIPLE,
@@ -859,6 +863,8 @@ KILIFI_FOLLOW_UP_CODING_PLANS = []
 KIAMBU_FOLLOW_UP_CODING_PLANS = []
 
 BUNGOMA_FOLLOW_UP_CODING_PLANS = []
+
+ALL_LOCATIONS_FOLLOW_UP_CODING_PLANS = []
 
 
 def get_follow_up_coding_plans(pipeline_name, analysis_mode=False):

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -127,7 +127,7 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.list_of_labels),
+               raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="kilifi_baseline_government_role_raw",
                time_field="kilifi_baseline_government_role_time",
@@ -143,7 +143,7 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.list_of_labels),
+               raw_field_fold_strategy=FoldStrategies.concatenate),
 ]
 
 KIAMBU_S01_RQA_CODING_PLANS = [

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -111,7 +111,37 @@ KILIFI_S01_RQA_CODING_PLANS = [
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("GPSDD KILIFI s01e05"),
-               raw_field_fold_strategy=FoldStrategies.concatenate)
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+
+    CodingPlan(raw_field="baseline_community_awareness_raw",
+               time_field="baseline_community_awareness_time",
+               coda_filename="GPSDD_KILIFI_baseline_community_awareness.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.KILIFI_BASELINE_COMMUNITY_AWARENESS,
+                       coded_field="baseline_community_awareness_coded",
+                       analysis_file_key="baseline_community_awareness",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="baseline_government_role_raw",
+               time_field="baseline_government_role_time",
+               coda_filename="GPSDD_KILIFI_baseline_government_role.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.KILIFI_BASELINE_GOVERNMENT_ROLE,
+                       coded_field="baseline_government_role_coded",
+                       analysis_file_key="baseline_government_role",
+                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.KILIFI_BASELINE_GOVERNMENT_ROLE)
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
 ]
 
 KIAMBU_S01_RQA_CODING_PLANS = [
@@ -203,7 +233,37 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("GPSDD KIAMBU s01e05"),
-               raw_field_fold_strategy=FoldStrategies.concatenate)
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+
+    CodingPlan(raw_field="baseline_community_awareness_raw",
+               time_field="baseline_community_awareness_time",
+               coda_filename="GPSDD_KIAMBU_baseline_community_awareness.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.KIAMBU_BASELINE_COMMUNITY_AWARENESS,
+                       coded_field="baseline_community_awareness_coded",
+                       analysis_file_key="baseline_community_awareness",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kiambu baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+    CodingPlan(raw_field="baseline_government_role_raw",
+               time_field="baseline_government_role_time",
+               coda_filename="GPSDD_KIAMBU_baseline_government_role.json",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.KIAMBU_BASELINE_GOVERNMENT_ROLE,
+                       coded_field="baseline_government_role_coded",
+                       analysis_file_key="baseline_government_role",
+                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.KIAMBU_BASELINE_GOVERNMENT_ROLE)
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kiambu baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.assert_equal),
 ]
 
 BUNGOMA_S01_RQA_CODING_PLANS = [
@@ -295,7 +355,39 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                    )
                ],
                ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("GPSDD BUNGOMA s01e05"),
-               raw_field_fold_strategy=FoldStrategies.concatenate)
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+
+    CodingPlan(raw_field="baseline_community_awareness_raw",
+               time_field="baseline_community_awareness_time",
+               coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
+               icr_filename="bungoma_baseline_community_awareness.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_COMMUNITY_AWARENESS,
+                       coded_field="baseline_community_awareness_coded",
+                       analysis_file_key="baseline_community_awareness",
+                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.BUNGOMA_BASELINE_COMMUNITY_AWARENESS)
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.concatenate),
+
+    CodingPlan(raw_field="baseline_government_role_raw",
+               time_field="baseline_government_role_time",
+               coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
+               icr_filename="bungoma_baseline_government_role.csv",
+               coding_configurations=[
+                   CodingConfiguration(
+                       coding_mode=CodingModes.MULTIPLE,
+                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE,
+                       coded_field="baseline_government_role_coded",
+                       analysis_file_key="baseline_government_role",
+                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE)
+                   )
+               ],
+               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
+               raw_field_fold_strategy=FoldStrategies.concatenate),
 ]
 
 def get_rqa_coding_plans(pipeline_name):
@@ -569,101 +661,11 @@ def get_demog_coding_plans(pipeline_name):
         return KILIFI_DEMOG_CODING_PLANS + KIAMBU_DEMOG_CODING_PLANS + BUNGOMA_DEMOG_CODING_PLANS
 
 
-KILIFI_FOLLOW_UP_CODING_PLANS = [
-    CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
-               coda_filename="GPSDD_KILIFI_baseline_community_awareness.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.SINGLE,
-                       code_scheme=CodeSchemes.KILIFI_BASELINE_COMMUNITY_AWARENESS,
-                       coded_field="baseline_community_awareness_coded",
-                       analysis_file_key="baseline_community_awareness",
-                       fold_strategy=FoldStrategies.assert_label_ids_equal
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
+KILIFI_FOLLOW_UP_CODING_PLANS = []
 
-    CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
-               coda_filename="GPSDD_KILIFI_baseline_government_role.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.MULTIPLE,
-                       code_scheme=CodeSchemes.KILIFI_BASELINE_GOVERNMENT_ROLE,
-                       coded_field="baseline_government_role_coded",
-                       analysis_file_key="baseline_government_role",
-                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.KILIFI_BASELINE_GOVERNMENT_ROLE)
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kilifi baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
-]
+KIAMBU_FOLLOW_UP_CODING_PLANS = []
 
-KIAMBU_FOLLOW_UP_CODING_PLANS = [
-    CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
-               coda_filename="GPSDD_KIAMBU_baseline_community_awareness.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.SINGLE,
-                       code_scheme=CodeSchemes.KIAMBU_BASELINE_COMMUNITY_AWARENESS,
-                       coded_field="baseline_community_awareness_coded",
-                       analysis_file_key="baseline_community_awareness",
-                       fold_strategy=FoldStrategies.assert_label_ids_equal
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kiambu baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
-
-    CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
-               coda_filename="GPSDD_KIAMBU_baseline_government_role.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.MULTIPLE,
-                       code_scheme=CodeSchemes.KIAMBU_BASELINE_GOVERNMENT_ROLE,
-                       coded_field="baseline_government_role_coded",
-                       analysis_file_key="baseline_government_role",
-                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.KIAMBU_BASELINE_GOVERNMENT_ROLE)
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("kiambu baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
-]
-
-BUNGOMA_FOLLOW_UP_CODING_PLANS = [
-    CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
-               coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.SINGLE,
-                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_COMMUNITY_AWARENESS,
-                       coded_field="baseline_community_awareness_coded",
-                       analysis_file_key="baseline_community_awareness",
-                       fold_strategy=FoldStrategies.assert_label_ids_equal
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
-
-    CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
-               coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
-               coding_configurations=[
-                   CodingConfiguration(
-                       coding_mode=CodingModes.MULTIPLE,
-                       code_scheme=CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE,
-                       coded_field="baseline_government_role_coded",
-                       analysis_file_key="baseline_government_role",
-                       fold_strategy=partial(FoldStrategies.list_of_labels, CodeSchemes.BUNGOMA_BASELINE_GOVERNMENT_ROLE)
-                   )
-               ],
-               ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("bungoma baseline community awareness"),
-               raw_field_fold_strategy=FoldStrategies.assert_equal),
-]
+BUNGOMA_FOLLOW_UP_CODING_PLANS = []
 
 
 def get_follow_up_coding_plans(pipeline_name):

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -114,7 +114,7 @@ KILIFI_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="kilifi_baseline_community_awareness_raw",
-               time_field="kilifi_baseline_community_awareness_time",
+               time_field="sent_on",
                coda_filename="GPSDD_KILIFI_baseline_community_awareness.json",
                icr_filename="kilifi_baseline_community_awareness.csv",
                coding_configurations=[
@@ -130,7 +130,7 @@ KILIFI_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="kilifi_baseline_government_role_raw",
-               time_field="kilifi_baseline_government_role_time",
+               time_field="sent_on",
                coda_filename="GPSDD_KILIFI_baseline_government_role.json",
                icr_filename="kilifi_baseline_government_role.csv",
                coding_configurations=[
@@ -238,7 +238,7 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="kiambu_baseline_community_awareness_raw",
-               time_field="kiambu_baseline_community_awareness_time",
+               time_field="sent_on",
                coda_filename="GPSDD_KIAMBU_baseline_community_awareness.json",
                icr_filename="kiambu_baseline_community_awareness.csv",
                coding_configurations=[
@@ -254,7 +254,7 @@ KIAMBU_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="kiambu_baseline_government_role_raw",
-               time_field="kiambu_baseline_government_role_time",
+               time_field="sent_on",
                coda_filename="GPSDD_KIAMBU_baseline_government_role.json",
                icr_filename="kiambu_baseline_government_role.csv",
                coding_configurations=[
@@ -362,7 +362,7 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="bungoma_baseline_community_awareness_raw",
-               time_field="bungoma_baseline_community_awareness_time",
+               time_field="sent_on",
                coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
                icr_filename="bungoma_baseline_community_awareness.csv",
                coding_configurations=[
@@ -378,7 +378,7 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="bungoma_baseline_government_role_raw",
-               time_field="bungoma_baseline_government_role_time",
+               time_field="sent_on",
                coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
                icr_filename="bungoma_baseline_government_role.csv",
                coding_configurations=[
@@ -476,7 +476,7 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="baseline_community_awareness_raw",
-               time_field="baseline_community_awareness_time",
+               time_field="sent_on",
                coda_filename="GPSDD_BUNGOMA_baseline_community_awareness.json",
                icr_filename="baseline_community_awareness.csv",
                coding_configurations=[
@@ -491,7 +491,7 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
                raw_field_fold_strategy=FoldStrategies.concatenate),
 
     CodingPlan(raw_field="baseline_government_role_raw",
-               time_field="baseline_government_role_time",
+               time_field="sent_on",
                coda_filename="GPSDD_BUNGOMA_baseline_government_role.json",
                icr_filename="bungoma_baseline_government_role.csv",
                coding_configurations=[

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -10,11 +10,11 @@
         "gpsdd_kiambu_s01e01_activation",
         "gpsdd_kiambu_s01e02_activation",
         "gpsdd_kiambu_s01e03_activation",
-        "gpsdd_kiambu_s01e04_activation"
+        "gpsdd_kiambu_s01e04_activation",
+        "gpsdd_kiambu_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kiambu_s01_demog",
-        "gpsdd_kiambu_s01_baseline"
+        "gpsdd_kiambu_s01_demog"
       ],
       "TestContactUUIDs": [
         "0793361d-c2cb-4a46-89ed-40ef05f5fa4f",

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -67,9 +67,9 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_kiambu_s01_demog", "PipelineKey": "kiambu_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_kiambu_s01_demog", "PipelineKey": "kiambu_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -68,9 +68,9 @@
     {"RapidProKey": "Disabled (Time) - gpsdd_kiambu_s01_demog", "PipelineKey": "kiambu_disabled_time"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "kiambu_baseline_government_role_time"}
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kiambu_s01_baseline", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -66,9 +66,9 @@
     {"RapidProKey": "Disabled (Text) - gpsdd_kilifi_s01_demog", "PipelineKey": "kilifi_disabled_raw"},
     {"RapidProKey": "Disabled (Time) - gpsdd_kilifi_s01_demog", "PipelineKey": "kilifi_disabled_time"},
 
-    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw"},
+    {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
-    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw"},
+    {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw", "IsActivationMessage":  true},
     {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -67,9 +67,9 @@
     {"RapidProKey": "Disabled (Time) - gpsdd_kilifi_s01_demog", "PipelineKey": "kilifi_disabled_time"},
 
     {"RapidProKey": "Community_Awareness (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_community_awareness_time"},
+    {"RapidProKey": "Community_Awareness (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "sent_on"},
     {"RapidProKey": "Government_Role (Text) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_raw", "IsActivationMessage":  true},
-    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "kilifi_baseline_government_role_time"}
+    {"RapidProKey": "Government_Role (Time) - gpsdd_kilifi_s01_baseline", "PipelineKey": "sent_on"}
   ],
   "ProjectStartDate": "2021-03-01T10:30:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -10,11 +10,11 @@
         "gpsdd_kilifi_s01e01_activation",
         "gpsdd_kilifi_s01e02_activation",
         "gpsdd_kilifi_s01e03_activation",
-        "gpsdd_kilifi_s01e04_activation"
+        "gpsdd_kilifi_s01e04_activation",
+        "gpsdd_kilifi_s01_baseline"
       ],
       "SurveyFlowNames": [
-        "gpsdd_kilifi_s01_demog",
-        "gpsdd_kilifi_s01_baseline"
+        "gpsdd_kilifi_s01_demog"
       ],
       "TestContactUUIDs": [
         "64918562-d983-4dce-8aa0-91df2879e10b",

--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -180,6 +180,10 @@ if __name__ == "__main__":
                 "kiambu_rqa_s01e05_coded": CodeSchemes.ALL_LOCATIONS_S01E05,
                 "bungoma_rqa_s01e05_coded": CodeSchemes.ALL_LOCATIONS_S01E05,
 
+                "kilifi_baseline_community_awareness_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS,
+                "kiambu_baseline_community_awareness_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS,
+                "bungoma_baseline_community_awareness_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS,
+
                 "kilifi_baseline_government_role_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE,
                 "kiambu_baseline_government_role_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE,
                 "bungoma_baseline_government_role_coded": CodeSchemes.ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE
@@ -241,7 +245,7 @@ if __name__ == "__main__":
                 "location_raw": assert_equal,
                 "disabled_raw": assert_equal,
 
-                "baseline_community_awareness_coded": partial(demog_labels, CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS),
+                "baseline_community_awareness_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_BASELINE_COMMUNITY_AWARENESS),
                 "baseline_government_role_coded": partial(FoldStrategies.list_of_labels, CodeSchemes.ALL_LOCATIONS_BASELINE_GOVERNMENT_ROLE),
 
                 "baseline_community_awareness_raw": assert_equal,

--- a/src/translate_rapid_pro_keys.py
+++ b/src/translate_rapid_pro_keys.py
@@ -26,18 +26,15 @@ class TranslateRapidProKeys(object):
         :type pipeline_configuration: PipelineConfiguration
         """
         for td in data:
-            show_dict = dict()
-
             for remapping in pipeline_configuration.rapid_pro_key_remappings:
                 if not remapping.is_activation_message:
                     continue
 
                 if td.get(remapping.rapid_pro_key) is not None:
-                    assert "rqa_message" not in show_dict
+                    show_dict = dict()
                     show_dict["rqa_message"] = td[remapping.rapid_pro_key]
                     show_dict["show_pipeline_key"] = remapping.pipeline_key
-
-            td.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+                    td.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
     @classmethod
     def _remap_radio_show_by_time_range(cls, user, data, time_key, show_pipeline_key_to_remap_to,

--- a/src/translate_rapid_pro_keys.py
+++ b/src/translate_rapid_pro_keys.py
@@ -25,16 +25,22 @@ class TranslateRapidProKeys(object):
         :param pipeline_configuration: Pipeline configuration.
         :type pipeline_configuration: PipelineConfiguration
         """
+        output = []
+
         for td in data:
             for remapping in pipeline_configuration.rapid_pro_key_remappings:
                 if not remapping.is_activation_message:
                     continue
 
                 if td.get(remapping.rapid_pro_key) is not None:
+                    x = td.copy()
                     show_dict = dict()
                     show_dict["rqa_message"] = td[remapping.rapid_pro_key]
                     show_dict["show_pipeline_key"] = remapping.pipeline_key
-                    td.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+                    x.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+                    output.append(x)
+
+        return output
 
     @classmethod
     def _remap_radio_show_by_time_range(cls, user, data, time_key, show_pipeline_key_to_remap_to,
@@ -195,7 +201,7 @@ class TranslateRapidProKeys(object):
         # Set the show pipeline key for each message, using the presence of Rapid Pro value keys in the TracedData.
         # These are necessary in order to be able to remap radio shows and key names separately (because data
         # can't be 'deleted' from TracedData).
-        cls.set_show_ids(user, data, pipeline_configuration)
+        data = cls.set_show_ids(user, data, pipeline_configuration)
 
         # Move rqa messages which ended up in the wrong flow to the correct one.
         cls.remap_radio_shows(user, data, pipeline_configuration)


### PR DESCRIPTION
As requested by RDA. This is mostly straightforward, the coding plans just move and have their fold strategies folded as appropriate. The one complexity is that follow-up flows can contain multiple messages (if we asked multiple questions in the same flow), but the pipeline expects one rqa message per TracedData initially, hence the tweak to translate_rapid_pro_keys.py.

@IsaackMwenda this is the last of the PRs I expect to open for GPSDD to complete our handover.