### PR TITLE
Tag listening groups participants

### DIFF
--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -72,7 +72,7 @@
     }
   ],
   "ListeningGroupCSVURLs": {
-    "health_practioners": [
+    "health_practitioners": [
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",

--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -71,24 +71,28 @@
       ]
     }
   ],
-  "ListeningGroupCSVURLs":[
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv"
-  ],
+  "ListeningGroupCSVURLs": {
+    "health_practioners": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv"
+    ],
+    "mothers": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv"
+      ]
+},
   "PhoneNumberUuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
     "TableName": "GPSDD_phone_number_avf_phone_id"

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -26,14 +26,18 @@
       ]
     }
   ],
-  "ListeningGroupCSVURLs":[
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv"
-  ],
+  "ListeningGroupCSVURLs": {
+    "health_practitioners": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv"
+    ],
+    "mothers": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv"
+    ]
+  },
   "PhoneNumberUuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
     "TableName": "GPSDD_phone_number_avf_phone_id"

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -24,7 +24,6 @@ def clean_age_with_range_filter(text):
 
 KILIFI_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kilifi_rqa_s01e01_raw",
-               listening_group_filename="gpsdd_kilifi_s01e01_listening_group.csv",
                time_field="sent_on",
                run_id_field="kilifi_rqa_s01e01_run_id",
                coda_filename="GPSDD_KILIFI_s01e01.json",
@@ -43,7 +42,6 @@ KILIFI_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kilifi_rqa_s01e02_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kilifi_s01e02_listening_group.csv",
                run_id_field="kilifi_rqa_s01e02_run_id",
                coda_filename="GPSDD_KILIFI_s01e02.json",
                icr_filename="kilifi_s01e02.csv",
@@ -61,7 +59,6 @@ KILIFI_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kilifi_rqa_s01e03_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kilifi_s01e03_listening_group.csv",
                run_id_field="kilifi_rqa_s01e03_run_id",
                coda_filename="GPSDD_KILIFI_s01e03.json",
                icr_filename="kilifi_s01e03.csv",
@@ -79,7 +76,6 @@ KILIFI_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kilifi_rqa_s01e04_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kilifi_s01e04_listening_group.csv",
                run_id_field="kilifi_rqa_s01e04_run_id",
                coda_filename="GPSDD_KILIFI_s01e04.json",
                icr_filename="kilifi_s01e04.csv",
@@ -97,7 +93,6 @@ KILIFI_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kilifi_rqa_s01e05_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kilifi_s01e05_listening_group.csv",
                run_id_field="kilifi_rqa_s01e05_run_id",
                coda_filename="GPSDD_KILIFI_s01e05.json",
                icr_filename="kilifi_s01e05.csv",
@@ -149,7 +144,6 @@ KILIFI_S01_RQA_CODING_PLANS = [
 KIAMBU_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="kiambu_rqa_s01e01_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kiambu_s01e02_listening_group.csv",
                run_id_field="kiambu_rqa_s01e01_run_id",
                coda_filename="GPSDD_KIAMBU_s01e01.json",
                icr_filename="kiambu_s01e01.csv",
@@ -167,7 +161,6 @@ KIAMBU_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kiambu_rqa_s01e02_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kiambu_s01e03_listening_group.csv",
                run_id_field="kiambu_rqa_s01e02_run_id",
                coda_filename="GPSDD_KIAMBU_s01e02.json",
                icr_filename="kiambu_s01e02.csv",
@@ -185,7 +178,6 @@ KIAMBU_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kiambu_rqa_s01e03_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kiambu_s01e03_listening_group.csv",
                run_id_field="kiambu_rqa_s01e03_run_id",
                coda_filename="GPSDD_KIAMBU_s01e03.json",
                icr_filename="kiambu_s01e03.csv",
@@ -203,7 +195,6 @@ KIAMBU_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kiambu_rqa_s01e04_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kiambu_s01e04_listening_group.csv",
                run_id_field="kiambu_rqa_s01e04_run_id",
                coda_filename="GPSDD_KIAMBU_s01e04.json",
                icr_filename="kiambu_s01e04.csv",
@@ -221,7 +212,6 @@ KIAMBU_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="kiambu_rqa_s01e05_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_kiambu_s01e05_listening_group.csv",
                run_id_field="kiambu_rqa_s01e05_run_id",
                coda_filename="GPSDD_KIAMBU_s01e05.json",
                icr_filename="kiambu_s01e05.csv",
@@ -273,7 +263,6 @@ KIAMBU_S01_RQA_CODING_PLANS = [
 BUNGOMA_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="bungoma_rqa_s01e01_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_bungoma_s01e01_listening_group.csv",
                run_id_field="bungoma_rqa_s01e01_run_id",
                coda_filename="GPSDD_BUNGOMA_s01e01.json",
                icr_filename="bungoma_s01e01.csv",
@@ -291,7 +280,6 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="bungoma_rqa_s01e02_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_bungoma_s01e02_listening_group.csv",
                run_id_field="bungoma_rqa_s01e02_run_id",
                coda_filename="GPSDD_BUNGOMA_s01e02.json",
                icr_filename="bungoma_s01e02.csv",
@@ -309,7 +297,6 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="bungoma_rqa_s01e03_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_bungoma_s01e03_listening_group.csv",
                run_id_field="bungoma_rqa_s01e03_run_id",
                coda_filename="GPSDD_BUNGOMA_s01e03.json",
                icr_filename="bungoma_s01e03.csv",
@@ -327,7 +314,6 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="bungoma_rqa_s01e04_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_bungoma_s01e04_listening_group.csv",
                run_id_field="bungoma_rqa_s01e04_run_id",
                coda_filename="GPSDD_BUNGOMA_s01e04.json",
                icr_filename="bungoma_s01e04.csv",
@@ -345,7 +331,6 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="bungoma_rqa_s01e05_raw",
                time_field="sent_on",
-               listening_group_filename="gpsdd_bungoma_s01e05_listening_group.csv",
                run_id_field="bungoma_rqa_s01e05_run_id",
                coda_filename="GPSDD_BUNGOMA_s01e05.json",
                icr_filename="bungoma_s01e05.csv",
@@ -397,7 +382,6 @@ BUNGOMA_S01_RQA_CODING_PLANS = [
 ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
     CodingPlan(raw_field="rqa_s01e01_raw",
                time_field="sent_on",
-               listening_group_filename="s01e01_listening_group.csv",
                run_id_field="rqa_s01e01_run_id",
                icr_filename="s01e01.csv",
                coding_configurations=[
@@ -413,7 +397,6 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="rqa_s01e02_raw",
                time_field="sent_on",
-               listening_group_filename="s01e02_listening_group.csv",
                run_id_field="rqa_s01e02_run_id",
                icr_filename="s01e02.csv",
                coding_configurations=[
@@ -429,7 +412,6 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="rqa_s01e03_raw",
                time_field="sent_on",
-               listening_group_filename="s01e03_listening_group.csv",
                run_id_field="rqa_s01e03_run_id",
                icr_filename="s01e03.csv",
                coding_configurations=[
@@ -445,7 +427,6 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="rqa_s01e04_raw",
                time_field="sent_on",
-               listening_group_filename="s01e04_listening_group.csv",
                run_id_field="rqa_s01e04_run_id",
                icr_filename="s01e04.csv",
                coding_configurations=[
@@ -461,7 +442,6 @@ ALL_LOCATIONS_S01_RQA_CODING_PLANS = [
 
     CodingPlan(raw_field="rqa_s01e05_raw",
                time_field="sent_on",
-               listening_group_filename="s01e05_listening_group.csv",
                run_id_field="rqa_s01e05_run_id",
                icr_filename="s01e05.csv",
                coding_configurations=[

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -25,12 +25,16 @@
       ]
     }
   ],
-  "ListeningGroupCSVURLs":[
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv"
-  ],
+  "ListeningGroupCSVURLs":{
+    "health_practitioners":[
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv"
+    ],
+    "mothers":[
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv"
+    ]
+  },
   "PhoneNumberUuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
     "TableName": "GPSDD_phone_number_avf_phone_id"

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -24,14 +24,18 @@
       ]
     }
   ],
-  "ListeningGroupCSVURLs":[
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv",
-    "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv"
+  "ListeningGroupCSVURLs": {
+    "health_practitioners": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv"
     ],
+    "mothers": [
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv"
+    ]
+  },
   "PhoneNumberUuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
     "TableName": "GPSDD_phone_number_avf_phone_id"

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -157,13 +157,19 @@ def fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_d
         log.info(f"Exported TracedData")
 
 def fetch_listening_groups_csvs(google_cloud_credentials_file_path, pipeline_configuration, raw_data_dir):
-    for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls:
-        listening_group = listening_group_csv_url.split("/")[-1]
+    for k, v in pipeline_configuration.listening_group_csv_urls.items():
+        for i, listening_group_csv_url in enumerate(v):
+            listening_group = listening_group_csv_url.split("/")[-1]
 
-        log.info(f"Saving '{listening_group}' to file '{raw_data_dir}'...")
-        with open(f'{raw_data_dir}/{listening_group}', "wb") as listening_group_output_file:
-            google_cloud_utils.download_blob_to_file(
-                google_cloud_credentials_file_path, listening_group_csv_url, listening_group_output_file)
+            if os.path.exists(f'{raw_data_dir}/{listening_group}'):
+                log.info(f"File '{raw_data_dir}/{listening_group}' for '{listening_group}' already exists;"
+                         f" skipping download")
+                continue
+
+            log.info(f"Saving '{listening_group}' to file '{raw_data_dir}'...")
+            with open(f'{raw_data_dir}/{listening_group}', "wb") as listening_group_output_file:
+                google_cloud_utils.download_blob_to_file(
+                    google_cloud_credentials_file_path, listening_group_csv_url, listening_group_output_file)
 
 def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_path, raw_data_dir):
     # Read the settings from the configuration file

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -81,7 +81,8 @@ class AnalysisFile(object):
         fold_strategies["uid"] = FoldStrategies.assert_equal
         fold_strategies[consent_withdrawn_key] = FoldStrategies.boolean_or
 
-        export_keys = ["uid", consent_withdrawn_key]
+        export_keys = ["uid", consent_withdrawn_key, "health_practitioners_listening_group_participant",
+                       "mothers_listening_group_participant"]
 
         for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
@@ -111,7 +112,7 @@ class AnalysisFile(object):
 
         # Tag listening group participants
         ListeningGroups.tag_listening_groups_participants(user, data, pipeline_configuration, raw_data_dir)
-        ListeningGroups.tag_listening_groups_participants(user, data, pipeline_configuration, raw_data_dir)
+        ListeningGroups.tag_listening_groups_participants(user, folded_data, pipeline_configuration, raw_data_dir)
 
         ConsentUtils.set_stopped(user, data, consent_withdrawn_key)
         ConsentUtils.set_stopped(user, folded_data, consent_withdrawn_key)

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -20,8 +20,7 @@ class CodingConfiguration(object):
 # TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
-                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
-                 listening_group_filename=None):
+                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None):
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -29,7 +28,6 @@ class CodingPlan(object):
         self.icr_filename = icr_filename
         self.coding_configurations = coding_configurations
         self.code_imputation_function = code_imputation_function
-        self.listening_group_filename = listening_group_filename
         self.ws_code = ws_code
         self.raw_field_fold_strategy = raw_field_fold_strategy
         self.dataset_name = raw_field

--- a/src/lib/listening_groups.py
+++ b/src/lib/listening_groups.py
@@ -32,7 +32,7 @@ class ListeningGroups(object):
 
         # Read listening group participants CSVs and add their uids to the respective group
         for k in listening_group_participants.keys():
-            for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls[f'{k}']:
+            for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls[k]:
                 listening_group_csv = listening_group_csv_url.split("/")[-1]
                 with open(f'{raw_data_dir}/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
                     listening_group_data = list(csv.DictReader(f))
@@ -44,9 +44,9 @@ class ListeningGroups(object):
         # Tag a participant based on the listening group type they belong to
         for td in data:
             listening_group_participation = dict() # of uid health_practitioner or mother lg participation data
-            listening_group_participation[f'health_practitioners_listening_group_participant'] = \
+            listening_group_participation['health_practitioners_listening_group_participant'] = \
                 td['uid'] in listening_group_participants['health_practitioners']
-            listening_group_participation[f'mothers_listening_group_participant'] = \
+            listening_group_participation['mothers_listening_group_participant'] = \
                 td['uid'] in listening_group_participants['mothers']
 
             td.append_data(listening_group_participation, Metadata(user, Metadata.get_call_location(), time.time()))

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 import pytz
 from core_data_modules.data_models import validators
 from dateutil.parser import isoparse
-import itertools
 
 from configuration import coding_plans
 

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import pytz
 from core_data_modules.data_models import validators
 from dateutil.parser import isoparse
+import itertools
 
 from configuration import coding_plans
 
@@ -56,8 +57,9 @@ class PipelineConfiguration(object):
         :type bucket_dir_path: str
         :param automated_analysis: Different Automated analysis Script Configurations
         :type automated_analysis: AutomatedAnalysis
-        :param listening_group_csv_urls: Google cloud storage urls to fetch listening group csvs from.
-        :type listening_group_csv_urls: list of str | None
+        :param listening_group_csv_urls: A dictionary containing Google cloud storage urls to fetch health_practitioners
+         and  mothers listening group participants csvs from.
+        :type listening_group_csv_urls: dict of lists | None
         """
         self.pipeline_name = pipeline_name
         self.raw_data_sources = raw_data_sources
@@ -175,9 +177,10 @@ class PipelineConfiguration(object):
         validators.validate_string(self.bucket_dir_path, "bucket_dir_path")
 
         if self.listening_group_csv_urls is not None:
-            validators.validate_list(self.listening_group_csv_urls, "listening_group_csv_urls")
-            for i, listening_group_csv_url in enumerate(self.listening_group_csv_urls):
-                validators.validate_string(listening_group_csv_url, f"{listening_group_csv_url}")
+            validators.validate_dict(self.listening_group_csv_urls, "listening_group_csv_urls")
+            for k, v in self.listening_group_csv_urls.items():
+                for i, listening_group_csv_url in enumerate(v):
+                    validators.validate_string(listening_group_csv_url, f"{listening_group_csv_url}")
 
 
 class RawDataSource(ABC):


### PR DESCRIPTION
This 

- Refactors Listeninggroupcsvurl to a dict containing health_practitioner & mothers LG groups.
- Tags UUIDs based on whether they are part of the two groups and adds `health_practitioners_listening_group_participant`, and `mothers_listening_group_participant` columns in the analysis file with bool values.
- Refactors fetch_raw_data to fetch the CSV url if they don't already exist in disk to save on read costs.