### PR TITLE
Fetch lg group csvs if they exixt in cloud

### DIFF
--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -89,28 +89,52 @@
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e08_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e03_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e08_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_health_practitioners_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e08_health_practitioners_listening_group.csv"
     ],
     "mothers": [
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e08_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e03_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e08_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_mothers_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e08_mothers_listening_group.csv"
 
       ]
 },
@@ -279,5 +303,7 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD"
+  "BucketDirPath": "2021/GPSDD",
+  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
+  "ListeningGroupBucketPath": "2021/GPSDD/"
 }

--- a/configuration/all_locations_pipeline_config.json
+++ b/configuration/all_locations_pipeline_config.json
@@ -303,7 +303,5 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD",
-  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
-  "ListeningGroupBucketPath": "2021/GPSDD/"
+  "BucketDirPath": "2021/GPSDD"
 }

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -165,7 +165,5 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/BUNGOMA",
-  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
-  "ListeningGroupBucketPath": "2021/GPSDD/"
+  "BucketDirPath": "2021/GPSDD/BUNGOMA"
 }

--- a/configuration/bungoma_pipeline_config.json
+++ b/configuration/bungoma_pipeline_config.json
@@ -35,13 +35,21 @@
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_health_practitioners_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_health_practitioners_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e08_health_practitioners_listening_group.csv"
     ],
     "mothers": [
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e03_mothers_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_mothers_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e04_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_bungoma_s01e08_mothers_listening_group.csv"
     ]
   },
   "PhoneNumberUuidTable": {
@@ -157,5 +165,7 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/BUNGOMA"
+  "BucketDirPath": "2021/GPSDD/BUNGOMA",
+  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
+  "ListeningGroupBucketPath": "2021/GPSDD/"
 }

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -166,7 +166,5 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/KIAMBU",
-  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
-  "ListeningGroupBucketPath": "2021/GPSDD/"
+  "BucketDirPath": "2021/GPSDD/KIAMBU"
 }

--- a/configuration/kiambu_pipeline_config.json
+++ b/configuration/kiambu_pipeline_config.json
@@ -35,13 +35,21 @@
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e03_health_practitioners_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_health_practitioners_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e08_health_practitioners_listening_group.csv"
     ],
     "mothers":[
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e03_mothers_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_mothers_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e04_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kiambu_s01e08_mothers_listening_group.csv"
     ]
   },
   "PhoneNumberUuidTable": {
@@ -158,5 +166,7 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/KIAMBU"
+  "BucketDirPath": "2021/GPSDD/KIAMBU",
+  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
+  "ListeningGroupBucketPath": "2021/GPSDD/"
 }

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -35,14 +35,21 @@
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_health_practitioners_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_health_practitioners_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_health_practitioners_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e06_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e07_health_practitioners_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e08_health_practitioners_listening_group.csv"
+
     ],
     "mothers": [
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e01_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e02_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e03_mothers_listening_group.csv",
       "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e04_mothers_listening_group.csv",
-      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_mothers_listening_group.csv"
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e05_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e06_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e07_mothers_listening_group.csv",
+      "gs://avf-project-datasets/2021/GPSDD/gpsdd_kilifi_s01e08_mothers_listening_group.csv"
     ]
   },
   "PhoneNumberUuidTable": {
@@ -155,5 +162,7 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/KILIFI"
+  "BucketDirPath": "2021/GPSDD/KILIFI",
+  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
+  "ListeningGroupBucketPath": "2021/GPSDD/"
 }

--- a/configuration/kilifi_pipeline_config.json
+++ b/configuration/kilifi_pipeline_config.json
@@ -162,7 +162,5 @@
   },
   "MemoryProfileUploadBucket": "gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2021/GPSDD/KILIFI",
-  "ProjectDatasetBucketURL": "gs://avf-project-datasets",
-  "ListeningGroupBucketPath": "2021/GPSDD/"
+  "BucketDirPath": "2021/GPSDD/KILIFI"
 }

--- a/export_weekly_advert_contacts.py
+++ b/export_weekly_advert_contacts.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import json
+import os
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.logging import Logger
@@ -83,13 +84,14 @@ if __name__ == "__main__":
     for listening_group_type in pipeline_configuration.listening_group_csv_urls.keys():
         for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls[listening_group_type]:
             listening_group_csv = listening_group_csv_url.split("/")[-1]
-            with open(f"{listening_group_data_dir}/{listening_group_csv}", "r", encoding='utf-8-sig') as f:
-                data = list(csv.DictReader(f))
-                log.info(
-                    f"Loaded {len(data)} listening group participants from {listening_group_data_dir}/{listening_group_csv}")
-                for row in data:
-                    uuids.add(row["avf-phone-uuid"])
-                    listening_group_participants += 1
+            if os.path.exists(f'{listening_group_data_dir}/{listening_group_csv}'):
+                with open(f"{listening_group_data_dir}/{listening_group_csv}", "r", encoding='utf-8-sig') as f:
+                    data = list(csv.DictReader(f))
+                    log.info(
+                        f"Loaded {len(data)} listening group participants from {listening_group_data_dir}/{listening_group_csv}")
+                    for row in data:
+                        uuids.add(row["avf-phone-uuid"])
+                        listening_group_participants += 1
     log.info(f"loaded {listening_group_participants} listening group participants")
 
     if exclusion_list_file_path is not None:

--- a/export_weekly_advert_contacts.py
+++ b/export_weekly_advert_contacts.py
@@ -92,6 +92,8 @@ if __name__ == "__main__":
                     for row in data:
                         uuids.add(row["avf-phone-uuid"])
                         listening_group_participants += 1
+            else:
+                log.warning(f"{listening_group_csv} not found in {listening_group_data_dir} skipping..")
     log.info(f"loaded {listening_group_participants} listening group participants")
 
     if exclusion_list_file_path is not None:

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -174,7 +174,7 @@ def fetch_listening_groups_csvs(google_cloud_credentials_file_path, pipeline_con
                         google_cloud_credentials_file_path, listening_group_csv_url, listening_group_output_file)
 
             except NotFound:
-                log.warning(f"{listening_group_csv}' not yet uploaded to google cloud skipping download")
+                log.warning(f"{listening_group_csv}' not found in google cloud, skipping download")
 
 
 def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_path, raw_data_dir):

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -157,17 +157,27 @@ def fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_d
         log.info(f"Exported TracedData")
 
 def fetch_listening_groups_csvs(google_cloud_credentials_file_path, pipeline_configuration, raw_data_dir):
+
+    uploaded_listening_group_files = [file.split("/")[-1] for file in google_cloud_utils.list_blobs(google_cloud_credentials_file_path,
+                                                                   pipeline_configuration.project_dataset_bucket_url,
+                                                                   pipeline_configuration.listening_group_bucket_path)]
+
     for k, v in pipeline_configuration.listening_group_csv_urls.items():
         for i, listening_group_csv_url in enumerate(v):
-            listening_group = listening_group_csv_url.split("/")[-1]
+            listening_group_csv = listening_group_csv_url.split("/")[-1]
 
-            if os.path.exists(f'{raw_data_dir}/{listening_group}'):
-                log.info(f"File '{raw_data_dir}/{listening_group}' for '{listening_group}' already exists;"
+            if listening_group_csv not in uploaded_listening_group_files:
+                log.info(f"{listening_group_csv}' not yet uploaded to {pipeline_configuration.project_dataset_bucket_url};"
                          f" skipping download")
                 continue
 
-            log.info(f"Saving '{listening_group}' to file '{raw_data_dir}'...")
-            with open(f'{raw_data_dir}/{listening_group}', "wb") as listening_group_output_file:
+            if os.path.exists(f'{raw_data_dir}/{listening_group_csv}'):
+                log.info(f"File '{raw_data_dir}/{listening_group_csv}' for '{listening_group_csv}' already exists;"
+                         f" skipping download")
+                continue
+
+            log.info(f"Saving '{listening_group_csv}' to file '{raw_data_dir}'...")
+            with open(f'{raw_data_dir}/{listening_group_csv}', "wb") as listening_group_output_file:
                 google_cloud_utils.download_blob_to_file(
                     google_cloud_credentials_file_path, listening_group_csv_url, listening_group_output_file)
 

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -168,7 +168,7 @@ def fetch_listening_groups_csvs(google_cloud_credentials_file_path, pipeline_con
                          f" skipping download")
                 continue
             try:
-                log.info(f"Saving '{listening_group_csv}' to file '{raw_data_dir}'...")
+                log.info(f"Saving '{listening_group_csv}' to file '{raw_data_dir}/{listening_group_csv}'...")
                 with open(f'{raw_data_dir}/{listening_group_csv}', "wb") as listening_group_output_file:
                     google_cloud_utils.download_blob_to_file(
                         google_cloud_credentials_file_path, listening_group_csv_url, listening_group_output_file)

--- a/src/lib/listening_groups.py
+++ b/src/lib/listening_groups.py
@@ -1,4 +1,5 @@
 import csv
+import os
 
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data import Metadata
@@ -34,10 +35,14 @@ class ListeningGroups(object):
         for k in listening_group_participants.keys():
             for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls[k]:
                 listening_group_csv = listening_group_csv_url.split("/")[-1]
-                with open(f'{raw_data_dir}/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
-                    listening_group_data = list(csv.DictReader(f))
-                    for row in listening_group_data:
-                        listening_group_participants[k].add(row['avf-phone-uuid'])
+
+                if os.path.exists(f'{raw_data_dir}/{listening_group_csv}'):
+                    with open(f'{raw_data_dir}/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
+                        listening_group_data = list(csv.DictReader(f))
+                        for row in listening_group_data:
+                            listening_group_participants[k].add(row['avf-phone-uuid'])
+                else:
+                    log.warning(f"{listening_group_csv} does not exist in {raw_data_dir} skipping!")
 
             log.info(f'Loaded {len(listening_group_participants[k])} {k} listening group participants')
 

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -20,7 +20,8 @@ class PipelineConfiguration(object):
     def __init__(self, pipeline_name, raw_data_sources, phone_number_uuid_table, operations_dashboard, timestamp_remappings,
                  rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,
                  memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
-                 automated_analysis, drive_upload=None, listening_group_csv_urls=None):
+                 automated_analysis, project_dataset_bucket_url, listening_group_bucket_path,
+                 drive_upload=None, listening_group_csv_urls=None):
         """
         :param pipeline_name: The name of this pipeline.
         :type pipeline_name: str
@@ -56,6 +57,10 @@ class PipelineConfiguration(object):
         :type bucket_dir_path: str
         :param automated_analysis: Different Automated analysis Script Configurations
         :type automated_analysis: AutomatedAnalysis
+        :param project_dataset_bucket_url: The GS bucket folder path to store the pipeline project datasets to.
+        :type project_dataset_bucket_url: str
+        :param listening_group_bucket_path: The GS bucket folder path to store the listening group files to.
+        :type listening_group_bucket_path: str
         :param listening_group_csv_urls: A dictionary containing Google cloud storage urls to fetch health_practitioners
          and  mothers listening group participants csvs from.
         :type listening_group_csv_urls: dict of lists | None
@@ -75,6 +80,8 @@ class PipelineConfiguration(object):
         self.data_archive_upload_bucket = data_archive_upload_bucket
         self.automated_analysis = automated_analysis
         self.bucket_dir_path = bucket_dir_path
+        self.project_dataset_bucket_url = project_dataset_bucket_url
+        self.listening_group_bucket_path = listening_group_bucket_path
         self.listening_group_csv_urls = listening_group_csv_urls
 
         PipelineConfiguration.RQA_CODING_PLANS = coding_plans.get_rqa_coding_plans(self.pipeline_name)
@@ -134,10 +141,14 @@ class PipelineConfiguration(object):
         data_archive_upload_bucket = configuration_dict["DataArchiveUploadBucket"]
         bucket_dir_path = configuration_dict["BucketDirPath"]
 
+        project_dataset_bucket_url = configuration_dict["ProjectDatasetBucketURL"]
+        listening_group_bucket_path = configuration_dict["ListeningGroupBucketPath"]
+
         return cls(pipeline_name, raw_data_sources, phone_number_uuid_table, operations_dashboard, timestamp_remappings,
                    rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages,
                    move_ws_messages, memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
-                   automated_analysis, drive_upload_paths, listening_group_csv_urls)
+                   automated_analysis, project_dataset_bucket_url, listening_group_bucket_path,
+                   drive_upload_paths, listening_group_csv_urls)
 
     @classmethod
     def from_configuration_file(cls, f):
@@ -166,14 +177,17 @@ class PipelineConfiguration(object):
         validators.validate_bool(self.filter_test_messages, "filter_test_messages")
         validators.validate_bool(self.move_ws_messages, "move_ws_messages")
 
+        validators.validate_url(self.memory_profile_upload_bucket, "memory_profile_upload_bucket", "gs")
+        validators.validate_url(self.data_archive_upload_bucket, "data_archive_upload_bucket", "gs")
+        validators.validate_string(self.bucket_dir_path, "bucket_dir_path")
+
+        validators.validate_url(self.project_dataset_bucket_url, "project_dataset_bucket_url", "gs")
+        validators.validate_string(self.listening_group_bucket_path, "project_dataset_bucket_url")
+
         if self.drive_upload is not None:
             assert isinstance(self.drive_upload, DriveUpload), \
                 "drive_upload is not of type DriveUpload"
             self.drive_upload.validate()
-
-        validators.validate_url(self.memory_profile_upload_bucket, "memory_profile_upload_bucket", "gs")
-        validators.validate_url(self.data_archive_upload_bucket, "data_archive_upload_bucket", "gs")
-        validators.validate_string(self.bucket_dir_path, "bucket_dir_path")
 
         if self.listening_group_csv_urls is not None:
             validators.validate_dict(self.listening_group_csv_urls, "listening_group_csv_urls")

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -20,8 +20,7 @@ class PipelineConfiguration(object):
     def __init__(self, pipeline_name, raw_data_sources, phone_number_uuid_table, operations_dashboard, timestamp_remappings,
                  rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,
                  memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
-                 automated_analysis, project_dataset_bucket_url, listening_group_bucket_path,
-                 drive_upload=None, listening_group_csv_urls=None):
+                 automated_analysis, drive_upload=None, listening_group_csv_urls=None):
         """
         :param pipeline_name: The name of this pipeline.
         :type pipeline_name: str
@@ -57,10 +56,6 @@ class PipelineConfiguration(object):
         :type bucket_dir_path: str
         :param automated_analysis: Different Automated analysis Script Configurations
         :type automated_analysis: AutomatedAnalysis
-        :param project_dataset_bucket_url: The GS bucket folder path to store the pipeline project datasets to.
-        :type project_dataset_bucket_url: str
-        :param listening_group_bucket_path: The GS bucket folder path to store the listening group files to.
-        :type listening_group_bucket_path: str
         :param listening_group_csv_urls: A dictionary containing Google cloud storage urls to fetch health_practitioners
          and  mothers listening group participants csvs from.
         :type listening_group_csv_urls: dict of lists | None
@@ -80,8 +75,6 @@ class PipelineConfiguration(object):
         self.data_archive_upload_bucket = data_archive_upload_bucket
         self.automated_analysis = automated_analysis
         self.bucket_dir_path = bucket_dir_path
-        self.project_dataset_bucket_url = project_dataset_bucket_url
-        self.listening_group_bucket_path = listening_group_bucket_path
         self.listening_group_csv_urls = listening_group_csv_urls
 
         PipelineConfiguration.RQA_CODING_PLANS = coding_plans.get_rqa_coding_plans(self.pipeline_name)
@@ -141,14 +134,10 @@ class PipelineConfiguration(object):
         data_archive_upload_bucket = configuration_dict["DataArchiveUploadBucket"]
         bucket_dir_path = configuration_dict["BucketDirPath"]
 
-        project_dataset_bucket_url = configuration_dict["ProjectDatasetBucketURL"]
-        listening_group_bucket_path = configuration_dict["ListeningGroupBucketPath"]
-
         return cls(pipeline_name, raw_data_sources, phone_number_uuid_table, operations_dashboard, timestamp_remappings,
                    rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages,
                    move_ws_messages, memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
-                   automated_analysis, project_dataset_bucket_url, listening_group_bucket_path,
-                   drive_upload_paths, listening_group_csv_urls)
+                   automated_analysis, drive_upload_paths, listening_group_csv_urls)
 
     @classmethod
     def from_configuration_file(cls, f):
@@ -180,9 +169,6 @@ class PipelineConfiguration(object):
         validators.validate_url(self.memory_profile_upload_bucket, "memory_profile_upload_bucket", "gs")
         validators.validate_url(self.data_archive_upload_bucket, "data_archive_upload_bucket", "gs")
         validators.validate_string(self.bucket_dir_path, "bucket_dir_path")
-
-        validators.validate_url(self.project_dataset_bucket_url, "project_dataset_bucket_url", "gs")
-        validators.validate_string(self.listening_group_bucket_path, "project_dataset_bucket_url")
 
         if self.drive_upload is not None:
             assert isinstance(self.drive_upload, DriveUpload), \


### PR DESCRIPTION
This allows us to add all the anticipated listening group files in the configuration and download them only if they exist in the cloud.